### PR TITLE
Fix values wheel a11y and footer typography

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -170,3 +170,10 @@ h2, h3, h4, h5, h6 {
 .readable-font h1, .readable-font h2, .readable-font h3, .readable-font h4, .readable-font h5, .readable-font h6 {
   font-family: 'Arial', sans-serif !important;
 }
+
+.values-wheel-hit:focus,
+.values-wheel-hit:focus-visible,
+.values-wheel-hit:-moz-focusring {
+  outline: none !important;
+  box-shadow: none !important;
+}

--- a/components/about_us/values.tsx
+++ b/components/about_us/values.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { JSX, useMemo, useState } from "react";
+import { JSX, KeyboardEvent, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const VALUE_DEFINITIONS = [
@@ -91,6 +91,16 @@ export default function Values(): JSX.Element {
   const { t } = useTranslation();
   const [activeIndex, setActiveIndex] = useState(0);
 
+  const handleSegmentKeyDown = (
+    event: KeyboardEvent<SVGPathElement>,
+    index: number
+  ): void => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setActiveIndex(index);
+    }
+  };
+
   const values = useMemo(() => {
     return VALUE_DEFINITIONS.map((valueDefinition) => ({
       ...valueDefinition,
@@ -112,7 +122,7 @@ export default function Values(): JSX.Element {
       <div className="mx-auto max-w-4xl">
         <div className="relative">
           <div className="relative aspect-[10/7] w-full">
-            <svg viewBox="0 0 1000 560" className="h-full w-full" aria-hidden="true">
+            <svg viewBox="0 0 1000 560" className="h-full w-full" aria-label={t("aboutUs.values.wheelLabel")}>
               {segments.map((segment, index) => {
                 const value = values[index];
                 const isActive = activeIndex === index;
@@ -137,12 +147,16 @@ export default function Values(): JSX.Element {
                       stroke="#ffffff"
                       strokeOpacity={0.001}
                       strokeWidth={18}
+                      className="values-wheel-hit cursor-pointer outline-none focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0 focus:shadow-none focus-visible:shadow-none"
+                      role="button"
+                      aria-label={value.title}
+                      aria-pressed={isActive}
+                      tabIndex={0}
                       onMouseEnter={() => setActiveIndex(index)}
                       onClick={() => setActiveIndex(index)}
                       onFocus={() => setActiveIndex(index)}
-                      style={{ cursor: "pointer" }}
-                      aria-label={value.title}
-                      tabIndex={0}
+                      onKeyDown={(event) => handleSegmentKeyDown(event, index)}
+                      style={{ outline: "none" }}
                     />
                   </g>
                 );
@@ -156,18 +170,14 @@ export default function Values(): JSX.Element {
               const yPercent = (segment.labelY / 560) * 100;
 
               return (
-                <button
+                <div
                   key={value.title}
-                  type="button"
-                  onMouseEnter={() => setActiveIndex(index)}
-                  onFocus={() => setActiveIndex(index)}
-                  onClick={() => setActiveIndex(index)}
-                  className="absolute -translate-x-1/2 -translate-y-1/2"
+                  className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2"
                   style={{
                     left: `${xPercent}%`,
                     top: `${yPercent}%`,
                   }}
-                  aria-label={value.title}
+                  aria-hidden="true"
                 >
                   <span
                     className={`inline-flex min-w-[104px] justify-center rounded-full px-3 py-2 text-[9px] font-black uppercase tracking-[0.22em] text-white transition-all duration-200 md:min-w-[132px] md:px-4 md:text-[11px] ${
@@ -178,7 +188,7 @@ export default function Values(): JSX.Element {
                   >
                     {value.title}
                   </span>
-                </button>
+                </div>
               );
             })}
 

--- a/components/home/footer.tsx
+++ b/components/home/footer.tsx
@@ -27,17 +27,13 @@ export default function Footer() {
                   className="relative transition-transform duration-500 group-hover:scale-105"
                 />
               </div>
-              <div>
-                <h2 className="text-red-600 font-contrail text-2xl leading-none tracking-tight">
-                  Fundación
-                </h2>
-                <p className="text-white/90 font-arimo font-bold text-lg tracking-wide">
-                  Lideres de Ansenuza
-                </p>
+              <div className="font-arimo text-base text-white leading-tight">
+                <p className="font-semibold tracking-wide">Fundación</p>
+                <p className="font-semibold tracking-wide">Lideres de Ansenuza</p>
               </div>
             </div>
 
-            <p className="text-gray-400 text-lg leading-relaxed max-w-md">
+            <p className="text-gray-400 font-arimo text-base leading-relaxed max-w-md">
               {t('footer.tagline')}
             </p>
 
@@ -64,13 +60,13 @@ export default function Footer() {
 
           {/* Contact Section */}
           <div className="md:col-span-6 lg:col-span-3 space-y-6">
-            <h3 className="text-xl font-contrail text-white tracking-wider uppercase">{t('footer.contact')}</h3>
-            <div className="space-y-4 text-gray-400 font-arimo">
+            <h3 className="text-base font-arimo font-semibold text-white tracking-wider uppercase">{t('footer.contact')}</h3>
+            <div className="space-y-4 text-gray-400 font-arimo text-base">
               <div className="group flex items-start gap-3">
                 <div className="mt-1 w-1.5 h-1.5 rounded-full bg-red-600 group-hover:scale-125 transition-transform" />
                 <div>
                   <p className="group-hover:text-white transition-colors">Independencia 350</p>
-                  <p className="group-hover:text-white transition-colors text-sm opacity-80">Miramar de Ansenuza, Córdoba</p>
+                  <p className="group-hover:text-white transition-colors opacity-80">Miramar de Ansenuza, Córdoba</p>
                 </div>
               </div>
               <div className="group flex items-center gap-3">
@@ -82,7 +78,7 @@ export default function Footer() {
               <div className="pt-2">
                 <a
                   href="/contactanos"
-                  className="inline-flex items-center text-red-500 font-bold hover:text-red-400 transition-colors gap-2 group/link"
+                  className="inline-flex items-center text-base font-arimo font-semibold text-white hover:text-white/80 transition-colors gap-2 group/link"
                 >
                   {t('footer.directContact')}
                   <span className="group-hover/link:translate-x-1 transition-transform">→</span>
@@ -93,15 +89,15 @@ export default function Footer() {
 
           {/* Newsletter Section */}
           <div className="md:col-span-6 lg:col-span-4 space-y-6">
-            <h3 className="text-xl font-contrail text-white tracking-wider uppercase">{t('footer.newsletter')}</h3>
-            <p className="text-gray-400 font-arimo">{t('footer.newsletterText')}</p>
+            <h3 className="text-base font-arimo font-semibold text-white tracking-wider uppercase">{t('footer.newsletter')}</h3>
+            <p className="text-gray-400 font-arimo text-base">{t('footer.newsletterText')}</p>
             <form className="relative flex group">
               <input
                 type="email"
                 placeholder={t('footer.emailPlaceholder')}
-                className="w-full pl-6 pr-16 py-4 rounded-2xl bg-white/5 border border-white/10 text-white placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-red-600/50 focus:border-red-600/50 transition-all"
+                className="w-full pl-6 pr-16 py-4 rounded-2xl bg-white/5 border border-white/10 text-white text-base font-arimo placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-red-600/50 focus:border-red-600/50 transition-all"
               />
-              <button className="absolute right-2 top-2 bottom-2 bg-red-600 hover:bg-red-700 text-white px-5 rounded-xl font-black transition-all transform active:scale-95 flex items-center justify-center">
+              <button className="absolute right-2 top-2 bottom-2 bg-red-600 hover:bg-red-700 text-white px-5 rounded-xl text-base font-arimo font-semibold transition-all transform active:scale-95 flex items-center justify-center">
                 <span>→</span>
               </button>
             </form>
@@ -110,15 +106,15 @@ export default function Footer() {
 
         {/* Footer Bottom */}
         <div className="mt-20 pt-10 border-t border-white/5 flex flex-col sm:flex-row justify-between items-center gap-6">
-          <p className="text-gray-500 font-arimo text-sm">
+          <p className="text-gray-500 font-arimo text-base">
             {t('footer.copyright', { year: new Date().getFullYear() })}
           </p>
-          <div className="flex items-center gap-8">
-            <a href="/politicas-de-privacidad" className="text-gray-500 hover:text-white text-sm font-medium transition-colors">
+          <div className="flex items-center gap-8 font-arimo text-base">
+            <a href="/politicas-de-privacidad" className="text-gray-500 hover:text-white font-medium transition-colors">
               {t('footer.privacyPolicy')}
             </a>
             <div className="w-1.5 h-1.5 rounded-full bg-white/10" />
-            <span className="text-gray-500 text-sm font-medium">
+            <span className="text-gray-500 font-medium">
               Argentina
             </span>
           </div>

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -86,6 +86,7 @@
       "imageAlt": "Foundation vision"
     },
     "values": {
+      "wheelLabel": "Interactive values wheel",
       "leadership": {
         "title": "LEADERSHIP",
         "description": "We not only cultivate this value in the people we work with, but also in our team and throughout the organization. We believe in leadership that includes, transforms, inspires, and makes things happen."

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -86,6 +86,7 @@
       "imageAlt": "Visión de la fundación"
     },
     "values": {
+      "wheelLabel": "Rueda interactiva de valores",
       "leadership": {
         "title": "LIDERAZGO",
         "description": "No solo cultivamos este valor en las personas con las que trabajamos, sino también en el equipo y en toda la organización. Creemos en un liderazgo que incluye, transforma, inspira y hace que las cosas pasen."


### PR DESCRIPTION
## Summary
### Rueda de valores (`about_us/values`)
- Eliminado el overlay interactivo de tipo botón sobre las etiquetas; las etiquetas son solo visuales (`pointer-events-none`) y mantienen el estado activo (pill, sombra, blur).
- La interacción queda en el path invisible del segmento SVG, con `role="button"`, `aria-pressed`, `Enter` y `Space`.
- Etiqueta accesible del SVG vía i18n (`aboutUs.values.wheelLabel` en `es` y `en`).
- Suprimido el rectángulo de foco nativo al tabular (Tailwind + regla `.values-wheel-hit` en `globals.css`).

### Footer
- Tipografía unificada con `font-arimo`, jerarquía más uniforme (`text-base` / `font-semibold`) y ajustes en contacto, newsletter y pie.

## Why
- Mejor UX y accesibilidad en la rueda sin el cuadro de foco molesto; footer más coherente visualmente con el resto del sitio.

## Validation
- `/quienes-somos`: clic y teclado en segmentos; foco sin rectángulo nativo.
- Revisión visual del footer en home (layout y enlaces).

## Follow-up (opcional)
- Indicador de foco custom con `focus-visible` en segmentos si se pide feedback explícito solo para teclado.