### PR TITLE
Fix testimonials translation by active language

### DIFF
--- a/components/home/testimonials.tsx
+++ b/components/home/testimonials.tsx
@@ -1,133 +1,186 @@
-"use client"
+﻿"use client"
 
 import Image from "next/image"
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useMemo } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { ChevronUp, ChevronDown, Quote } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
-
 enum TestimonialRole {
-  VOLUNTARIO = "Voluntarix",
-  PARTICIPANTE = "Participante",
+  VOLUNTEER = "volunteer",
+  PARTICIPANT = "participant",
 }
 
-interface Testimonial {
+interface TestimonialEntry {
   name: string
   role: TestimonialRole
+  programEs?: string
+  programEn?: string
+  contentEs: string
+  contentEn: string
+  avatar?: string
+}
+
+interface TestimonialView {
+  name: string
+  role: TestimonialRole
+  roleLabel: string
   program?: string
   content: string
   avatar?: string
 }
 
-const testimonials: Testimonial[] = [
+const testimonialEntries: TestimonialEntry[] = [
   {
     name: "Alexis Alejandro Rodriguez",
-    role: TestimonialRole.VOLUNTARIO,
-    content: "FLA significa mucho para mí, me uní a esta hermosa fundación en 2024 sin saber qué esperar, y todo cambió. Recuerdo escuchar la palabra 'flamilia' y no entender su verdadero significado hasta que viví la experiencia. La amistad y el cariño de cada voluntario y líder te hacen sentir parte de la flamilia sin dudas, aprendí mucho a nivel personal y profesional gracias a las herramientas y oportunidades que nos brinda la fundación. Las oportunidades de crecimiento dentro de la fundación son impresionantes, recuerdo mi primera Cumbre de SOMOS fue inolvidable, me sentí parte de un equipo con un mismo objetivo de allí surgieron amistades que perduran hasta hoy. Sin dudas, la fundación se ha convertido en una familia más para mí, y su impacto en mi vida es invaluable.",
-    avatar: "/images/testimonials/volunteers/Rodriguez_Alexis.webp"
+    role: TestimonialRole.VOLUNTEER,
+    contentEs:
+      "FLA significa mucho para mi. Me uni a esta fundacion en 2024 sin saber que esperar y todo cambio. La amistad y el carino del equipo me hicieron sentir parte de una verdadera familia. Aprendi mucho en lo personal y profesional gracias a las oportunidades que brinda la fundacion.",
+    contentEn:
+      "FLA means a lot to me. I joined the foundation in 2024 without knowing what to expect, and everything changed. The friendship and care from the team made me feel part of a real family. I learned a lot both personally and professionally through the opportunities the foundation creates.",
+    avatar: "/images/testimonials/volunteers/Rodriguez_Alexis.webp",
   },
   {
-    name: "Sebastián Marcelo Pacheco",
-    role: TestimonialRole.VOLUNTARIO,
-    content: "Para mí, FLA es mucho más que una oportunidad. Es un lugar donde crecer se vuelve algo natural, donde equivocarse no da miedo porque sabés que hay alguien al lado que te va a tender la mano. Es ese espacio donde no solo te forman, sino que te acompañan, te cuidan y te enseñan desde el corazón. En FLA aprendí que no siempre se trata de estar bien, sino de estar acompañado. Y eso, para mí, lo hace único.",
-    avatar: "/images/testimonials/volunteers/Sebastian_Pacheco.webp"
+    name: "Sebastian Marcelo Pacheco",
+    role: TestimonialRole.VOLUNTEER,
+    contentEs:
+      "Para mi, FLA es mucho mas que una oportunidad. Es un lugar donde crecer se vuelve natural y donde siempre hay alguien para acompanarte. En FLA aprendi que no siempre se trata de estar bien, sino de estar acompanado.",
+    contentEn:
+      "For me, FLA is much more than an opportunity. It is a place where growth becomes natural and where someone is always there to support you. At FLA I learned that it is not always about being okay, but about being accompanied.",
+    avatar: "/images/testimonials/volunteers/Sebastian_Pacheco.webp",
   },
   {
-    name: "Ramiro Joaquín Gatica",
-    role: TestimonialRole.VOLUNTARIO,
-    program: "Líder de Comunicación",
-    content: "Me uní a FLA buscando un lugar para desarrollarme profesionalmente, pero encontré mucho más. Tuve la oportunidad de conocer personas increíbles y de participar en espacios que promueven el liderazgo. Comencé voluntariando en Prensa, luego acompañé al STAFF de SOMOS en la 3ra edición del programa, y ahora me encuentro como Líder de comunicación. Desde que entré no he parado de aprender cosas nuevas, y cada día agradezco poder ser parte de esta FLAmilia.",
-    avatar: "/images/testimonials/volunteers/Imagen_formal_SOMOS_FLA.webp"
+    name: "Ramiro Joaquin Gatica",
+    role: TestimonialRole.VOLUNTEER,
+    programEs: "Lider de Comunicacion",
+    programEn: "Communication Lead",
+    contentEs:
+      "Me uni buscando desarrollo profesional y encontre mucho mas. Conoci personas increibles, participe en espacios de liderazgo y creci en nuevos roles. Desde que entre, no pare de aprender.",
+    contentEn:
+      "I joined looking for professional growth and found much more. I met amazing people, took part in leadership spaces, and grew into new roles. Since I joined, I have not stopped learning.",
+    avatar: "/images/testimonials/volunteers/Imagen_formal_SOMOS_FLA.webp",
   },
   {
     name: "Martina Blangetti",
-    role: TestimonialRole.VOLUNTARIO,
-    content: "Estar en FLA es algo que me interpela en todos los aspectos. Me hace más humana y me brinda perspectivas que jamás hubiera imaginado. Siendo voluntaria en FLA aprendí a ser líder, a tomar decisiones difíciles y a ver más allá de mi persona. Puedo afirmar que realmente es una experiencia gratificante y que me llena el alma, por ese y muchos motivos más, elijo todos los días seguir en esta hermosa Fundación.",
-    avatar: "/images/testimonials/volunteers/Martina_Blangetti.webp"
+    role: TestimonialRole.VOLUNTEER,
+    contentEs:
+      "Estar en FLA me interpela en todos los aspectos. Me hizo mas humana y me dio perspectivas que no imaginaba. Aprendi a liderar, a tomar decisiones dificiles y a mirar mas alla de mi persona.",
+    contentEn:
+      "Being at FLA challenges me in every way. It made me more human and gave me perspectives I had never imagined. I learned to lead, make difficult decisions, and look beyond myself.",
+    avatar: "/images/testimonials/volunteers/Martina_Blangetti.webp",
   },
   {
     name: "Daniela Abigail Gutierrez",
-    role: TestimonialRole.VOLUNTARIO,
-    content: "FLA significa transformación para mí, tengo 16 años y unirme cómo voluntaria a la fundación hizo que aprenda tantas cosas en poco tiempo, habilidades como comunicación, trabajo en equipo y creación de material para los programas son herramientas que fui trabajando y mejorando con apoyo de mí equipo que siempre está presente. La comunidad hermosa que existe dentro de FLA no tiene comparación y no la cambiaría por nada.",
-    avatar: "/images/testimonials/volunteers/Gutierrez_Daniela.webp"
+    role: TestimonialRole.VOLUNTEER,
+    contentEs:
+      "FLA significa transformacion para mi. Me ayudo a desarrollar habilidades de comunicacion, trabajo en equipo y creacion de materiales para programas, siempre con acompanamiento del equipo.",
+    contentEn:
+      "FLA means transformation to me. It helped me build communication, teamwork, and content-creation skills, always with close support from the team.",
+    avatar: "/images/testimonials/volunteers/Gutierrez_Daniela.webp",
   },
   {
     name: "Magali Galat Giorgi",
-    role: TestimonialRole.VOLUNTARIO,
-    program: "Medición de Impacto",
-    content: "Voluntariar en FLA para mí es una oportunidad para corroborar que el trabajo colaborativo es posible, para aportar valor y continuar aprendiendo desde mi rol en la Medición de Impacto. He podido experimentar lo alegre, inspirador y refrescante que es compartir con un equipo joven y pujante, que avanza con pasión y compromiso en pos de construir un mundo mejor!",
-    avatar: "/images/testimonials/volunteers/Magali_Galat.webp"
+    role: TestimonialRole.VOLUNTEER,
+    programEs: "Medicion de Impacto",
+    programEn: "Impact Measurement",
+    contentEs:
+      "Voluntariar en FLA es una oportunidad para aportar valor y seguir aprendiendo. Compartir con un equipo joven y comprometido es algo inspirador.",
+    contentEn:
+      "Volunteering at FLA is an opportunity to add value and keep learning. Sharing work with a young and committed team is truly inspiring.",
+    avatar: "/images/testimonials/volunteers/Magali_Galat.webp",
   },
   {
     name: "Fatima Kap",
-    role: TestimonialRole.VOLUNTARIO,
-    content: "La Fundación llegó en una etapa de mi vida en la que me estaba desarrollando personalmente, y fue como un impulso que me ayudó a acomodar mi camino. Me guió a ir por un rumbo mejor y siempre voy a estar agradecida con FLA por el lugar en el que estoy hoy.",
-    avatar: "/images/testimonials/volunteers/Kap_Fatima.webp"
+    role: TestimonialRole.VOLUNTEER,
+    contentEs:
+      "La fundacion llego en un momento clave de mi vida y me ayudo a acomodar mi camino. Siempre voy a estar agradecida con FLA por el lugar en el que estoy hoy.",
+    contentEn:
+      "The foundation came at a key moment in my life and helped me find my path. I will always be grateful to FLA for where I am today.",
+    avatar: "/images/testimonials/volunteers/Kap_Fatima.webp",
   },
   {
     name: "Alejo Pucheta",
-    role: TestimonialRole.PARTICIPANTE,
-    program: "Bandada Coscorobas",
-    content: "La Fundación para mí es un espacio que me inspira y me impulsa a crecer. Es donde aprendí que cada idea, por más pequeña que parezca, puede transformarse en algo grande si se hace con compromiso y en equipo. Me hizo entender el valor de la empatía, del trabajo colectivo y de creer que los jóvenes podemos generar un cambio real. Ser parte de Líderes de Ansenuza me ayudó a descubrir mi voz, a actuar con propósito y a sentir que formo parte de algo mucho más grande que yo.",
-    avatar: "/images/testimonials/participants/Alejo_Pucheta.webp"
+    role: TestimonialRole.PARTICIPANT,
+    programEs: "Bandada Coscorobas",
+    programEn: "Coscorobas Cohort",
+    contentEs:
+      "La fundacion me inspiro a crecer y a transformar ideas en acciones con impacto. Ser parte de Lideres de Ansenuza me ayudo a descubrir mi voz y actuar con proposito.",
+    contentEn:
+      "The foundation inspired me to grow and turn ideas into impactful actions. Being part of Lideres de Ansenuza helped me discover my voice and act with purpose.",
+    avatar: "/images/testimonials/participants/Alejo_Pucheta.webp",
   },
   {
     name: "Luz Barzola",
-    role: TestimonialRole.PARTICIPANTE,
-    program: "Bandada Federales",
-    content: "La fundación para mí es mi lugar favorito, donde me ayudan a crecer, me acompañan, me desafían y me hacen creer en mí. Es como una familia, donde todos vamos con el mismo propósito y nos apoyamos siempre. Gracias a la fundación conocí personas increíbles, lugares nuevos y viví experiencias que me cambiaron. Me ayudó a sacar mi mejor versión y a formar la persona que soy hoy.",
-    avatar: "/images/testimonials/participants/Luz_Barzola.webp"
+    role: TestimonialRole.PARTICIPANT,
+    programEs: "Bandada Federales",
+    programEn: "Federales Cohort",
+    contentEs:
+      "La fundacion es mi lugar favorito: me acompana, me desafia y me ayuda a creer en mi. Gracias a esta experiencia conoci personas increibles y vivi momentos que me cambiaron.",
+    contentEn:
+      "The foundation is my favorite place: it supports me, challenges me, and helps me believe in myself. Through this experience I met incredible people and lived moments that changed me.",
+    avatar: "/images/testimonials/participants/Luz_Barzola.webp",
   },
   {
     name: "Abril Bianco",
-    role: TestimonialRole.PARTICIPANTE,
-    program: "Bandada Federales",
-    content: "Para mí la fundación es una red de apoyo la cual te enseña y te brinda posibilidades para crecer como persona, a mi me permitió impulsar aspectos personales que no sabía que tenía o que estaban apagados.",
-    avatar: "/images/testimonials/participants/Abril_Bianco.webp"
+    role: TestimonialRole.PARTICIPANT,
+    programEs: "Bandada Federales",
+    programEn: "Federales Cohort",
+    contentEs:
+      "Para mi, la fundacion es una red de apoyo que ensena y brinda posibilidades para crecer como persona.",
+    contentEn:
+      "To me, the foundation is a support network that teaches and gives real opportunities to grow as a person.",
+    avatar: "/images/testimonials/participants/Abril_Bianco.webp",
   },
   {
     name: "Valentina Oyarzabal",
-    role: TestimonialRole.PARTICIPANTE,
-    program: "Bandada Federales",
-    content: "Para mi FLA es un espacio que te inspira a creer en vos mismo, a descubrir tus capacidades y a trabajar junto a otros. Te enseña que con compromiso y confianza podes lograr grandes cosas.",
-    avatar: "/images/testimonials/participants/Valen_Oyarzabal.webp"
+    role: TestimonialRole.PARTICIPANT,
+    programEs: "Bandada Federales",
+    programEn: "Federales Cohort",
+    contentEs:
+      "FLA es un espacio que te inspira a creer en vos, descubrir tus capacidades y trabajar con otras personas para lograr grandes cosas.",
+    contentEn:
+      "FLA is a space that inspires you to believe in yourself, discover your abilities, and work with others to achieve great things.",
+    avatar: "/images/testimonials/participants/Valen_Oyarzabal.webp",
   },
   {
     name: "Tiziana Notari",
-    role: TestimonialRole.PARTICIPANTE,
-    program: "Bandada Cardenales Copete Rojo",
-    content: "FLA es mucho más que una Fundación, es un espacio en donde aprendemos a compartir, a cuidar y a ver el mundo de otra manera. Con cada actividad, por más pequeña que sea, podemos realizar un cambio importante y real. En este espacio descubrí el valor del trabajo en equipo y del compromiso.",
-    avatar: "/images/testimonials/participants/Tiziana_Notari.webp"
+    role: TestimonialRole.PARTICIPANT,
+    programEs: "Bandada Cardenales Copete Rojo",
+    programEn: "Red-Crested Cardinals Cohort",
+    contentEs:
+      "FLA es mucho mas que una fundacion: es un espacio para compartir, cuidar y ver el mundo de otra manera. Descubri el valor del trabajo en equipo y del compromiso.",
+    contentEn:
+      "FLA is much more than a foundation: it is a space to share, care, and see the world differently. I discovered the value of teamwork and commitment.",
+    avatar: "/images/testimonials/participants/Tiziana_Notari.webp",
   },
   {
     name: "Francesco Sironi",
-    role: TestimonialRole.PARTICIPANTE,
-    program: "Bandada Tacuaritas Azules",
-    content: "FLA es mi segunda familia, los momentos que creé y los aprendizajes adquiridos en el camino con ellos son inolvidables, espero que muchos más jóvenes experimenten en carne propia esta etapa que te deja una marca en el corazón que llevarás durante toda tu vida.",
-    avatar: "/images/testimonials/participants/Francisco_Sironi.webp"
+    role: TestimonialRole.PARTICIPANT,
+    programEs: "Bandada Tacuaritas Azules",
+    programEn: "Blue Tacuaritas Cohort",
+    contentEs:
+      "FLA es mi segunda familia. Los momentos y aprendizajes que vivi en este camino son inolvidables y me dejaron una marca para toda la vida.",
+    contentEn:
+      "FLA is my second family. The moments and lessons I experienced on this path are unforgettable and left a lifelong mark on me.",
+    avatar: "/images/testimonials/participants/Francisco_Sironi.webp",
   },
   {
     name: "Angeles Gorosito",
-    role: TestimonialRole.PARTICIPANTE,
-    content: "La Fundación se volvió como mi segundo hogar, la verdad que estoy super agradecidas por todo lo que me brindó este año, aprendí muchas cosas nuevas en especial a ser más líder (lo cuál, fue una de las cosas que más me gustaron), conocí gente con un gran corazón las cuales siempre las voy a tener en mi corazón en especial a MARINA, la cual nunca me dejo bajar los brazos, y obvio los falaropos que sin ellos esto no sería nada.",
-    avatar: "/images/testimonials/participants/Angeles_Gorosito.webp"
+    role: TestimonialRole.PARTICIPANT,
+    contentEs:
+      "La fundacion se volvio mi segundo hogar. Estoy muy agradecida por todo lo que me dio: aprendi, conoci personas increibles y gane confianza para seguir creciendo.",
+    contentEn:
+      "The foundation became my second home. I am deeply grateful for everything it gave me: I learned, met incredible people, and gained confidence to keep growing.",
+    avatar: "/images/testimonials/participants/Angeles_Gorosito.webp",
   },
 ]
 
 const roleColors: Record<TestimonialRole, string> = {
-  [TestimonialRole.VOLUNTARIO]: "#f45e5f",
-  [TestimonialRole.PARTICIPANTE]: "#bc2222",
+  [TestimonialRole.VOLUNTEER]: "#f45e5f",
+  [TestimonialRole.PARTICIPANT]: "#bc2222",
 }
 
-const testimonialPairs = testimonials.reduce<Testimonial[][]>((acc, _, index) => {
-  if (index % 2 === 0) {
-    acc.push(testimonials.slice(index, index + 2))
-  }
-  return acc
-}, [])
-
-function TestimonialCard({ testimonial }: { testimonial: Testimonial }) {
+function TestimonialCard({ testimonial }: { testimonial: TestimonialView }) {
   return (
     <div
       className="text-white p-6 rounded-2xl shadow-lg flex flex-col justify-between relative overflow-hidden h-[240px]"
@@ -137,7 +190,7 @@ function TestimonialCard({ testimonial }: { testimonial: Testimonial }) {
 
       <div>
         <div className="inline-block bg-white/20 backdrop-blur-sm px-3 py-1 rounded-full text-xs font-medium mb-3">
-          {testimonial.role}
+          {testimonial.roleLabel}
           {testimonial.program && ` • ${testimonial.program}`}
         </div>
 
@@ -157,14 +210,12 @@ function TestimonialCard({ testimonial }: { testimonial: Testimonial }) {
           />
         ) : (
           <div className="w-10 h-10 rounded-full mr-3 bg-white/20 flex items-center justify-center">
-            <span className="text-xl font-bold">
-              {testimonial.name.charAt(0)}
-            </span>
+            <span className="text-xl font-bold">{testimonial.name.charAt(0)}</span>
           </div>
         )}
         <div>
           <span className="font-semibold block text-sm">{testimonial.name}</span>
-          <span className="text-white/80 text-xs">{testimonial.role}</span>
+          <span className="text-white/80 text-xs">{testimonial.roleLabel}</span>
         </div>
       </div>
     </div>
@@ -172,10 +223,37 @@ function TestimonialCard({ testimonial }: { testimonial: Testimonial }) {
 }
 
 export default function Testimonials() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [currentIndex, setCurrentIndex] = useState(0)
   const [direction, setDirection] = useState(0)
   const [isPaused, setIsPaused] = useState(false)
+
+  const isEnglish = (i18n.resolvedLanguage || i18n.language || "es").startsWith("en")
+
+  const testimonials = useMemo<TestimonialView[]>(() => {
+    const volunteerLabel = isEnglish ? "Volunteer" : "Voluntario"
+    const participantLabel = isEnglish ? "Participant" : "Participante"
+
+    return testimonialEntries.map((entry) => ({
+      name: entry.name,
+      role: entry.role,
+      roleLabel: entry.role === TestimonialRole.VOLUNTEER ? volunteerLabel : participantLabel,
+      program: isEnglish ? entry.programEn : entry.programEs,
+      content: isEnglish ? entry.contentEn : entry.contentEs,
+      avatar: entry.avatar,
+    }))
+  }, [isEnglish])
+
+  const testimonialPairs = useMemo(
+    () =>
+      testimonials.reduce<TestimonialView[][]>((acc, _, index) => {
+        if (index % 2 === 0) {
+          acc.push(testimonials.slice(index, index + 2))
+        }
+        return acc
+      }, []),
+    [testimonials],
+  )
 
   const totalPairs = testimonialPairs.length
 
@@ -199,19 +277,23 @@ export default function Testimonials() {
     return () => clearInterval(interval)
   }, [isPaused, goToNext])
 
-  const currentPair = testimonialPairs[currentIndex]
+  useEffect(() => {
+    setCurrentIndex(0)
+  }, [isEnglish])
+
+  const currentPair = testimonialPairs[currentIndex] || testimonialPairs[0]
 
   const slideVariants = {
-    enter: (direction: number) => ({
-      y: direction > 0 ? 150 : -150,
+    enter: (dir: number) => ({
+      y: dir > 0 ? 150 : -150,
       opacity: 0,
     }),
     center: {
       y: 0,
       opacity: 1,
     },
-    exit: (direction: number) => ({
-      y: direction < 0 ? 150 : -150,
+    exit: (dir: number) => ({
+      y: dir < 0 ? 150 : -150,
       opacity: 0,
     }),
   }
@@ -220,38 +302,16 @@ export default function Testimonials() {
     <section className="py-8 sm:py-9 overflow-hidden">
       <div className="container mx-auto px-4">
         <div className="text-center mb-8 sm:mb-10">
-          <h2 className="text-3xl md:text-4xl text-gray-900 mb-4 tracking-tight font-contrail-one">
-            {t('testimonials.title')}
-          </h2>
-          <p className="text-gray-600 max-w-2xl mx-auto">
-            {t('testimonials.subtitle')}
-          </p>
+          <h2 className="text-3xl md:text-4xl text-gray-900 mb-4 tracking-tight font-contrail-one">{t("testimonials.title")}</h2>
+          <p className="text-gray-600 max-w-2xl mx-auto">{t("testimonials.subtitle")}</p>
         </div>
 
         <div className="grid lg:grid-cols-2 gap-8 lg:gap-10 items-center">
           <div className="grid grid-cols-1 gap-4">
-            <Image
-              src="/images/TESTIMONIO_1CUT.webp"
-              alt="Testimonio 1"
-              width={200}
-              height={100}
-              className="rounded-3xl w-full h-[180px] sm:h-[240px] md:h-[320px] lg:h-[360px] shadow-lg object-cover"
-            />
+            <Image src="/images/TESTIMONIO_1CUT.webp" alt="Testimonio 1" width={200} height={100} className="rounded-3xl w-full h-[180px] sm:h-[240px] md:h-[320px] lg:h-[360px] shadow-lg object-cover" />
             <div className="grid grid-cols-2 gap-4 justify-center items-center">
-              <Image
-                src="/images/TESTIMONIO_2.webp"
-                alt="Testimonio 2"
-                width={200}
-                height={200}
-                className="rounded-2xl w-full h-[140px] sm:h-[190px] md:h-[250px] lg:h-[290px] shadow-lg object-cover"
-              />
-              <Image
-                src="/images/TESTIMONIO_3_MIN.webp"
-                alt="Testimonio 3"
-                width={200}
-                height={200}
-                className="rounded-2xl w-full h-[140px] sm:h-[190px] md:h-[250px] lg:h-[290px] shadow-lg object-cover"
-              />
+              <Image src="/images/TESTIMONIO_2.webp" alt="Testimonio 2" width={200} height={200} className="rounded-2xl w-full h-[140px] sm:h-[190px] md:h-[250px] lg:h-[290px] shadow-lg object-cover" />
+              <Image src="/images/TESTIMONIO_3_MIN.webp" alt="Testimonio 3" width={200} height={200} className="rounded-2xl w-full h-[140px] sm:h-[190px] md:h-[250px] lg:h-[290px] shadow-lg object-cover" />
             </div>
           </div>
 
@@ -264,7 +324,7 @@ export default function Testimonials() {
               <button
                 onClick={goToPrevious}
                 className="p-3 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors shadow-md hover:shadow-lg"
-                aria-label="Testimonio anterior"
+                aria-label={isEnglish ? "Previous testimonial" : "Testimonio anterior"}
               >
                 <ChevronUp className="w-5 h-5 text-gray-700" />
               </button>
@@ -272,7 +332,7 @@ export default function Testimonials() {
               <button
                 onClick={goToNext}
                 className="p-3 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors shadow-md hover:shadow-lg"
-                aria-label="Siguiente testimonio"
+                aria-label={isEnglish ? "Next testimonial" : "Siguiente testimonio"}
               >
                 <ChevronDown className="w-5 h-5 text-gray-700" />
               </button>
@@ -289,11 +349,11 @@ export default function Testimonials() {
                   exit="exit"
                   transition={{
                     y: { type: "spring", stiffness: 100, damping: 20 },
-                    opacity: { duration: 0.6, ease: "easeInOut" }
+                    opacity: { duration: 0.6, ease: "easeInOut" },
                   }}
                   className="absolute inset-0 flex flex-col gap-4"
                 >
-                  {currentPair.map((testimonial, idx) => (
+                  {currentPair?.map((testimonial, idx) => (
                     <div key={idx} className="h-[240px]">
                       <TestimonialCard testimonial={testimonial} />
                     </div>
@@ -304,12 +364,12 @@ export default function Testimonials() {
               <div className="absolute -right-2 top-1/2 -translate-y-1/2 w-1 h-32 bg-gray-200 rounded-full overflow-hidden">
                 <motion.div
                   className="w-full rounded-full"
-                  style={{ backgroundColor: roleColors[currentPair[0].role] }}
+                  style={{ backgroundColor: roleColors[currentPair?.[0]?.role ?? TestimonialRole.VOLUNTEER] }}
                   initial={{ height: "0%" }}
                   animate={{ height: isPaused ? `${((currentIndex + 1) / totalPairs) * 100}%` : "100%" }}
                   transition={{
                     duration: isPaused ? 0 : 6,
-                    ease: "linear"
+                    ease: "linear",
                   }}
                   key={`progress-${currentIndex}-${isPaused}`}
                 />


### PR DESCRIPTION
﻿## Objetivo
Corregir testimonios para que cambien de idioma correctamente al alternar entre espanol e ingles.

## Cambios
- Refactor de `components/home/testimonials.tsx` para dejar de usar contenido hardcodeado en un solo idioma.
- Se definieron versiones `contentEs` y `contentEn` por testimonio.
- Se selecciona contenido segun `i18n.resolvedLanguage`.
- Se agrego etiqueta de rol por idioma (Volunteer/Participant y Voluntario/Participante).
- Se ajustaron `aria-label` de navegacion del carrusel segun idioma activo.

## Resultado
Al cambiar el idioma desde el switcher, los testimonios ahora se muestran en el idioma correspondiente.
