### PR TITLE
Programas: centrar 3er programa activo en layout triangular

### DIFF
--- a/app/programas/programas-page-client.tsx
+++ b/app/programas/programas-page-client.tsx
@@ -78,11 +78,15 @@ export default function ProgramasPage() {
               </p>
 
               <div className="grid md:grid-cols-2 gap-12 lg:gap-16 items-start justify-items-center">
-                {ACTIVE_PROGRAMS.map((program) => (
+                {ACTIVE_PROGRAMS.map((program, index) => (
                   <Link
                     key={program.slug}
                     href={`/programas/${program.slug}`}
-                    className="group w-full max-w-md"
+                    className={`group w-full max-w-md ${
+                      ACTIVE_PROGRAMS.length === 3 && index === 2
+                        ? "md:col-span-2 md:justify-self-center"
+                        : ""
+                    }`}
                   >
                     <div className="flex flex-col items-center transition-all duration-300">
                       <div


### PR DESCRIPTION
## Resumen\n- ajusta la grilla de programas activos en /programas\n- cuando hay exactamente 3 programas activos, centra la tercera card en desktop (md:col-span-2 md:justify-self-center)\n- mantiene comportamiento responsive en mobile (1 columna) y tablet/desktop (2 columnas)\n\n## Archivo\n- pp/programas/programas-page-client.tsx\n\n## Notas\n- cambio aislado en una rama limpia para no mezclar otros cambios locales