### PR TITLE
Refresh i18n and donation flow

### DIFF
--- a/app/donar/donation-page-client.tsx
+++ b/app/donar/donation-page-client.tsx
@@ -1,6 +1,6 @@
 ﻿"use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { CheckCircle2, Globe, CreditCard, Landmark, Mail, Copy } from "lucide-react"
@@ -8,6 +8,140 @@ import { useTranslation } from "react-i18next"
 
 const DARK_BROWN = "#90140e"
 const DONAR_ONLINE_URL = "https://donaronline.org/fundacion-lideres-de-ansenuza/fundacion-lideres-de-ansenuza"
+const PAYPAL_SDK_URL = "https://www.paypalobjects.com/donate/sdk/donate-sdk.js"
+const PAYPAL_DONATE_CONTAINER_ID = "paypal-donate-button-container"
+
+const PAYPAL_HOSTED_BUTTON_ID = process.env.NEXT_PUBLIC_PAYPAL_DONATE_HOSTED_BUTTON_ID?.trim() ?? ""
+const PAYPAL_BUSINESS = process.env.NEXT_PUBLIC_PAYPAL_DONATE_BUSINESS?.trim() ?? ""
+const PAYPAL_ENV = process.env.NEXT_PUBLIC_PAYPAL_DONATE_ENV?.trim() || "production"
+
+declare global {
+  interface Window {
+    PayPal?: {
+      Donation?: {
+        Button: (config: Record<string, unknown>) => { render: (selector: string) => void }
+      }
+    }
+    __paypalDonateSdkPromise?: Promise<void>
+  }
+}
+
+function loadPayPalDonateSdk() {
+  if (typeof window === "undefined") {
+    return Promise.resolve()
+  }
+
+  if (window.PayPal?.Donation?.Button) {
+    return Promise.resolve()
+  }
+
+  if (window.__paypalDonateSdkPromise) {
+    return window.__paypalDonateSdkPromise
+  }
+
+  window.__paypalDonateSdkPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${PAYPAL_SDK_URL}"]`)
+
+    if (existing) {
+      existing.addEventListener("load", () => resolve(), { once: true })
+      existing.addEventListener("error", () => reject(new Error("No se pudo cargar PayPal Donate SDK")), { once: true })
+      return
+    }
+
+    const script = document.createElement("script")
+    script.src = PAYPAL_SDK_URL
+    script.async = true
+    script.charset = "UTF-8"
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error("No se pudo cargar PayPal Donate SDK"))
+    document.body.appendChild(script)
+  })
+
+  return window.__paypalDonateSdkPromise
+}
+
+function PayPalDonateWidget() {
+  const [status, setStatus] = useState<"idle" | "loading" | "ready" | "error" | "missing-config">("idle")
+
+  useEffect(() => {
+    if (!PAYPAL_HOSTED_BUTTON_ID && !PAYPAL_BUSINESS) {
+      setStatus("missing-config")
+      return
+    }
+
+    let cancelled = false
+
+    const renderDonateButton = async () => {
+      setStatus("loading")
+
+      try {
+        await loadPayPalDonateSdk()
+
+        if (cancelled) {
+          return
+        }
+
+        const container = document.getElementById(PAYPAL_DONATE_CONTAINER_ID)
+        if (!container || !window.PayPal?.Donation?.Button) {
+          setStatus("error")
+          return
+        }
+
+        container.innerHTML = ""
+
+        const config: Record<string, unknown> = {
+          env: PAYPAL_ENV,
+          image: {
+            src: "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif",
+            title: "PayPal - The safer, easier way to pay online!",
+            alt: "Donate with PayPal button",
+          },
+        }
+
+        if (PAYPAL_HOSTED_BUTTON_ID) {
+          config.hosted_button_id = PAYPAL_HOSTED_BUTTON_ID
+        } else {
+          config.business = PAYPAL_BUSINESS
+        }
+
+        window.PayPal.Donation.Button(config).render(`#${PAYPAL_DONATE_CONTAINER_ID}`)
+        setStatus("ready")
+      } catch {
+        if (!cancelled) {
+          setStatus("error")
+        }
+      }
+    }
+
+    renderDonateButton()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="flex w-full flex-col items-center gap-4">
+      <div id={PAYPAL_DONATE_CONTAINER_ID} className="min-h-12" />
+
+      {status === "loading" && (
+        <p className="text-sm font-arimo text-gray-500">Cargando boton de PayPal...</p>
+      )}
+
+      {status === "missing-config" && (
+        <p className="max-w-lg text-center text-sm font-arimo text-[#90140e]">
+          Configura NEXT_PUBLIC_PAYPAL_DONATE_HOSTED_BUTTON_ID (o NEXT_PUBLIC_PAYPAL_DONATE_BUSINESS) para habilitar el boton.
+        </p>
+      )}
+
+      {status === "error" && (
+        <p className="max-w-lg text-center text-sm font-arimo text-[#90140e]">
+          No pudimos cargar PayPal en este momento. Intenta nuevamente en unos segundos.
+        </p>
+      )}
+    </div>
+  )
+}
 
 function TimelineSteps({ steps, accent }: { steps: string[]; accent: string }) {
   return (
@@ -219,7 +353,7 @@ export default function DonationPage() {
                 <WelcomeNote />
 
                 <div className="flex justify-center">
-                  <DonationChip href="https://www.paypal.com/donate/?hosted_button_id=X6VW3LVURRPSN" />
+                  <PayPalDonateWidget />
                 </div>
               </div>
             )}
@@ -303,4 +437,3 @@ export default function DonationPage() {
     </>
   )
 }
-

--- a/components/contactanos/contact-intro.tsx
+++ b/components/contactanos/contact-intro.tsx
@@ -1,14 +1,15 @@
 ﻿"use client"
 
+import { useTranslation } from "react-i18next"
+
 export default function ContactIntro() {
+  const { t } = useTranslation()
+
   return (
     <div className="px-4 pb-4 pt-10 md:pb-6 md:pt-12">
-      <div className="max-w-[1535px] mx-auto text-center">
-        <h1 className="font-contrail-one text-black text-6xl md:text-7xl">
-          Contáctanos
-        </h1>
+      <div className="mx-auto max-w-[1535px] text-center">
+        <h1 className="font-contrail-one text-6xl text-black md:text-7xl">{t("contact.title")}</h1>
       </div>
     </div>
   )
 }
-

--- a/lib/data/programs-en.ts
+++ b/lib/data/programs-en.ts
@@ -1,0 +1,871 @@
+import type { ProgramData } from './programs';
+
+export const AMBIENTALIA_DATA_EN: ProgramData = {
+  title: 'Ambientalia Experience',
+  slug: 'ambientalia',
+  status: 'active',
+  shortDescription:
+    'Environmental education program that connects young people with their ecosystems and biodiversity while developing leadership skills through community-based environmental projects.',
+  fullDescription:
+    'Ambientalia Experience is an environmental education program developed by Fundacion Lideres de Ansenuza together with Manomet Conservation Sciences and the RHRAP Executive Office. It has been held annually since 2021. The program seeks to connect young people with their ecosystems and biodiversity while also developing leadership skills through the design and implementation of community-based environmental projects.',
+  location:
+    'The program was born at the RHRAP Laguna Mar Chiquita site in inland Cordoba, Argentina. In addition to being implemented there, it is also carried out at other important shorebird sites, mainly saline lakes, such as the Laguna de los Pozuelos Natural Monument in Jujuy and lakes in the United States including Mono Lake, the Great Salt Lake, Walker Lake, and Lake Abert. The program is led at each site by local partners, and its length, activities, and focus may vary.',
+  duration: '8 months',
+  modality:
+    'The program uses a blended, multi-platform format. It includes in-person sessions, live virtual sessions, and asynchronous virtual work, with an effort to balance both modalities. It is a completely free opportunity for all participants.',
+  requirements: [
+    'Be a high school student in the upper secondary cycle (4th, 5th, 6th, or 7th year).',
+    'Attend a school located in one of the following communities: Miramar de Ansenuza, Balnearia, Marull, La Para, Obispo Trejo, Altos de Chipion, Villa Rosario del Saladillo, Las Arrias, Toro Pujio, La Puerta, Villa Fontana, La Posta, Sebastian Elcano, La Paquita, Morteros, Brinkmann, Seeber, Portena, Colonia San Pedro, or Colonia Vignaud. The program also works in La Rinconada.',
+    'Registration is done in groups of at least 3 students and at most 7 students.',
+    'Each team must have a teacher mentor. Maximum of two lead teachers.'
+  ],
+  enrollmentInfo: {
+    description:
+      'To apply, you must complete a registration form, usually available each year between March and April. The form asks for information about each group member, questions about your project idea, and a video submission.',
+    availablePeriod: 'March - April (annually)'
+  },
+  stages: [
+    {
+      title: 'Teacher training',
+      description:
+        'Virtual and in-person learning spaces support teachers throughout the process and provide tools to teach about the Ansenuza region.',
+      icon: 'GraduationCap'
+    },
+    {
+      title: 'Online classes and challenges',
+      description:
+        'Virtual microlearning classes guide participants step by step in developing research, conservation, or sustainable entrepreneurship projects while also presenting challenges that foster creativity and critical thinking.',
+      icon: 'Monitor'
+    },
+    {
+      title: 'School visits',
+      description:
+        'The program team visits each participating school to provide personalized feedback to students and teachers, helping them move their projects forward and overcome specific challenges.',
+      icon: 'School'
+    },
+    {
+      title: 'Field trips',
+      description:
+        'Visits to natural areas in the region allow participants to observe local biodiversity, understand environmental issues firsthand, and strengthen their connection to the site.',
+      icon: 'TreePine'
+    },
+    {
+      title: 'International and community events',
+      description:
+        'Monthly activities connect students from Mar Chiquita with young people from different countries and communities through virtual exchanges, shared workshops, and collaborative actions that build a broader perspective and a hemispheric sense of community.',
+      icon: 'Globe'
+    },
+    {
+      title: 'Community engagement',
+      description:
+        'An outreach commitment promotes sharing environmental projects with the wider community, running community workshops, and building local partnerships.',
+      icon: 'Users'
+    },
+    {
+      title: 'Leadership',
+      description:
+        'Each participant receives personalized follow-up to support the development of soft skills.',
+      icon: 'Award'
+    },
+    {
+      title: 'Interaction',
+      description:
+        'Virtual games about the Ansenuza region help participants connect while learning about ecology, conservation, and related topics.',
+      icon: 'Gamepad2'
+    },
+    {
+      title: 'Project fair',
+      description:
+        'An event where participants present to the community the projects they designed and implemented during the program. The most outstanding initiatives receive great prizes.',
+      icon: 'Trophy'
+    },
+    {
+      title: 'Environmental Leaders Forum',
+      description:
+        'The final activity of the year brings together the most outstanding participants for a day of intensive training, workshops, and talks with experts in conservation and sustainable development.',
+      icon: 'MessageSquare'
+    }
+  ],
+  stats: [
+    {
+      label: 'Years of experience',
+      value: '4+'
+    },
+    {
+      label: 'Students and teachers trained',
+      value: '700+'
+    },
+    {
+      label: 'Participating communities',
+      value: '21+'
+    },
+    {
+      label: 'Community projects developed',
+      value: '62'
+    }
+  ],
+  successStories: [
+    {
+      title: 'Present at the creation of Ansenuza National Park',
+      description:
+        'On June 30, 2022, a group of Ambientalia students had the privilege of being present in the Argentine Senate during the historic session in which the law declaring the region Ansenuza National Park was passed.'
+    },
+    {
+      title: 'First youth exchange between saline lakes',
+      description:
+        'In 2024, five students and one teacher from the Mar Chiquita region had a transformative experience traveling to California, United States, to take part in the first youth exchange between saline lakes, an unprecedented initiative that connected young communities from two sister ecosystems: Laguna Mar Chiquita and Mono Lake.'
+    },
+    {
+      title: 'Impact on local public policy',
+      description:
+        'Over the past few years, several projects developed by young people through Ambientalia went beyond the classroom and had a concrete impact on local and provincial public policy. Thanks to their research, commitment, and advocacy, students from different communities helped drive municipal ordinances that promote environmental protection.'
+    }
+  ],
+  blogPosts: [
+    {
+      title: 'Ambientalia Experience carries out its first international exchange to the United States',
+      url: 'https://www.lideresdeansenuza.org/2024/07/25/experiencia-ambientalia-realiza-su-primer-intercambio-internacional-a-estados-unidos/'
+    },
+    {
+      title: 'A new cultural exchange for Ambientalia Experience',
+      url: 'https://www.lideresdeansenuza.org/2024/09/30/un-nuevo-intercambio-cultural-para-experiencia-ambientalia/'
+    },
+    {
+      title: 'VN Global’s major gesture with Ambientalia Experience and the community of La Rinconada',
+      url: 'https://www.lideresdeansenuza.org/2024/10/08/el-gran-gesto-de-vn-global-con-experiencia-ambientalia-y-la-localidad-de-la-rinconada/'
+    },
+    {
+      title: 'An inspiring day',
+      url: 'https://www.lideresdeansenuza.org/2024/11/25/una-jornada-inspiradora/'
+    }
+  ],
+  faqs: [
+    {
+      question: 'Can I have more than two teachers as mentors? Do they have to be from my school?',
+      answer:
+        'You can have at least one official teacher mentor and at most two. More teachers may support the group as alternates, but they would not be eligible for program prizes. They do not need to be from your school.'
+    },
+    {
+      question: 'What happens if my teammates drop out and I am the only one left?',
+      answer:
+        'In that case, as long as you want to continue, we will try to place you in another team that can welcome you so you can remain in the program. There are always participants ready to receive new people. You can also finish the program on your own.'
+    }
+  ],
+  sponsors: [
+    {
+      name: 'USDA USFS'
+    },
+    {
+      name: 'Epam'
+    },
+    {
+      name: 'USFWS'
+    }
+  ],
+  gallery: {
+    type: 'drive',
+    url: 'https://drive.google.com/drive/folders/1nICN2r6FvOQVpWSZVEaC_McTJkc-ShL1'
+  },
+  colors: {
+    primary: '#10b981',
+    secondary: '#059669',
+    accent: '#34d399'
+  }
+};
+
+export const SOMOS_DATA_EN: ProgramData = {
+  title: 'SOMOS',
+  slug: 'somos',
+  status: 'active',
+  shortDescription:
+    'Free diversity leadership program for young people ages 15 to 19 in Argentina who want to become leaders in their communities.',
+  fullDescription:
+    'SOMOS is a free diversity leadership program for young people ages 15 to 19 in Argentina who want to become leaders in their communities. Over 2 months, participants learn about diversity, develop leadership skills, and carry out a social impact action that transforms their community. They do this through workshops with experts, personalized mentoring, and exclusive materials created especially for the program.',
+  location:
+    'SOMOS comes to FLA to open spaces for dialogue, debate, and collective learning while promoting the organization’s values. We believe in a more just, equal, empathetic, and respectful society, and we know change begins with each of us.',
+  duration: '2 months',
+  modality: 'Virtual program with workshops, personalized mentoring, and exclusive materials.',
+  requirements: [
+    'Be between 15 and 19 years old.',
+    'Be a high school student in any province of Argentina.',
+    'Be eager to learn about diversity, leadership, and self-awareness.',
+    'Commit to building a fairer and more inclusive society by carrying out an impact action in your community.'
+  ],
+  enrollmentInfo: {
+    description:
+      'To join the program, you must complete the registration form available on our website.',
+    availablePeriod: 'Check enrollment dates'
+  },
+  stages: [
+    {
+      title: 'Learn',
+      description:
+        'Diversity workshops, a personal development handbook, a project development handbook, and weekly mentoring.',
+      icon: 'BookOpen'
+    },
+    {
+      title: 'Take action',
+      description:
+        'Time to implement your impact action in your community. You will have exclusive materials and staff support throughout the process.',
+      icon: 'Rocket'
+    },
+    {
+      title: 'Closing',
+      description:
+        'We share the actions carried out and participants can then become part of the FLA community.',
+      icon: 'PartyPopper'
+    }
+  ],
+  stats: [
+    {
+      label: 'Editions held',
+      value: '3'
+    },
+    {
+      label: 'Participants',
+      value: '70+'
+    },
+    {
+      label: 'People reached',
+      value: '4000+'
+    }
+  ],
+  successStories: [
+    {
+      title: 'Fighting teenage suicide',
+      description:
+        'She is determined not to abandon them: the fight of a teenager in the province with the highest suicide rate in the country.',
+      link: 'https://www.lanacion.com.ar/comunidad/esta-decidida-a-no-abandonarlos-la-lucha-de-una-adolescente-en-la-provincia-con-mas-suicidios-del-nid29042025/'
+    }
+  ],
+  blogPosts: [
+    {
+      title: 'Discover what the SOMOS 2024 Summit in Tucuman was like',
+      url: 'https://www.lideresdeansenuza.org/2024/12/17/descubri-lo-que-fue-la-cumbre-de-somos-2024-en-tucuman/'
+    },
+    {
+      title: 'Discover what the Diversathon was like',
+      url: 'https://www.lideresdeansenuza.org/2024/11/23/descubri-lo-que-fue-el-diversathon/'
+    }
+  ],
+  faqs: [
+    {
+      question: 'Is there an age limit?',
+      answer:
+        'You can apply if you are between 15 and 19 years old and are a high school student in any province of Argentina.'
+    },
+    {
+      question: 'Is there any monetary cost?',
+      answer: 'None. The program is completely free.'
+    },
+    {
+      question: 'Are there any requirements to apply?',
+      answer:
+        'You should be eager to learn about diversity, leadership, and self-awareness, and be committed to contributing to a fairer and more inclusive society by carrying out an impact action in your community.'
+    },
+    {
+      question: 'What diversity topics are covered in the program?',
+      answer:
+        'Cultural, body, functional, gender, sexual, religious, and political diversity.'
+    },
+    {
+      question: 'Is it necessary to complete an impact action to graduate?',
+      answer:
+        'Yes. Completing an impact action is a core requirement to finish the program. You will have exclusive materials and staff support throughout the process.'
+    },
+    {
+      question: 'How do I apply?',
+      answer: 'By completing the registration form on our website.'
+    }
+  ],
+  sponsors: [],
+  gallery: {
+    type: 'images',
+    images: []
+  },
+  colors: {
+    primary: '#8b5cf6',
+    secondary: '#7c3aed',
+    accent: '#a78bfa'
+  }
+};
+
+export const POTENCIATE_DATA_EN: ProgramData = {
+  title: 'Potenciate',
+  slug: 'potenciate',
+  status: 'historical',
+  year: '2021',
+  shortDescription:
+    'Disruptive twelve-week mentoring program designed to inspire young people in Argentina to discover their passion and become changemakers capable of driving social impact projects.',
+  fullDescription:
+    'Potenciate was a disruptive twelve-week mentoring program designed to inspire young people in Argentina to discover their passion and become changemakers capable of driving social impact projects.',
+  location:
+    'The program expanded to 11 provinces in Argentina, with a focus on Catamarca and the central region of the country.',
+  duration: '12 weeks',
+  modality:
+    'Virtual program with weekly one-on-one mentoring combined with activities, challenges, and games, along with group sessions with specialists and official workshops.',
+  requirements: [
+    'Learners: young people ages 15 to 17 interested in self-awareness and project management.',
+    'Mentors: young changemakers with proven experience in volunteering and social impact project management.'
+  ],
+  enrollmentInfo: {
+    description:
+      'This program took place in 2021 and is not currently open for enrollment.',
+    availablePeriod: 'Program completed'
+  },
+  stages: [
+    {
+      title: 'Know Yourself',
+      description:
+        'A self-awareness stage where participants explored their strengths, values, and passions.',
+      icon: 'User'
+    },
+    {
+      title: 'Get Inspired',
+      description:
+        'Networking with leaders and specialists who inspired participants through their experiences.',
+      icon: 'Lightbulb'
+    },
+    {
+      title: 'Take Action',
+      description:
+        'Execution of social impact projects with the support of mentors.',
+      icon: 'Rocket'
+    }
+  ],
+  stats: [
+    {
+      label: 'Provinces reached',
+      value: '11'
+    },
+    {
+      label: 'Graduates',
+      value: '35'
+    },
+    {
+      label: 'Editions held',
+      value: '1'
+    }
+  ],
+  successStories: [
+    {
+      title: 'A platform for inspiration and networking',
+      description:
+        'The program served as a platform for inspiration and networking so young people could take action and launch social impact projects. Eighty-eight percent of participants considered the exercise handbook one of the most useful tools.'
+    }
+  ],
+  blogPosts: [],
+  faqs: [],
+  sponsors: [
+    {
+      name: 'Embassy of the United States in Argentina'
+    },
+    {
+      name: 'Global Changemakers'
+    }
+  ],
+  gallery: {
+    type: 'images',
+    images: []
+  },
+  colors: {
+    primary: '#f97316',
+    secondary: '#ea580c',
+    accent: '#fb923c'
+  }
+};
+
+export const FUTURAS_DATA_EN: ProgramData = {
+  title: 'FUTURAS',
+  slug: 'futuras',
+  status: 'historical',
+  year: '2017-2024',
+  shortDescription:
+    'Free and innovative leadership, mentoring, and women’s empowerment program designed for young women in Argentina to develop self-awareness and gain project management tools to solve community problems.',
+  fullDescription:
+    'FUTURAS was a free and innovative leadership, mentoring, and women’s empowerment program designed for young women in Argentina to develop self-awareness and gain project management tools to solve community problems. With seven editions held, the program sought to form leaders committed to their communities and aware of the importance of women’s leadership.',
+  location:
+    'It included the in-person Women Leaders Summit in Miramar de Ansenuza, Cordoba, where participants traveled to meet one another, build a network of changemakers, and draw direct inspiration from leading women and role models.',
+  duration: 'Varies by edition',
+  modality:
+    'Blended format, virtual and in person, with one-on-one mentoring in pairs and specialized workshops with asynchronous training.',
+  requirements: [
+    'Learners: women ages 15 to 19 from any province in Argentina.',
+    'Mentors: women over 20 with experience in leadership or mentoring.'
+  ],
+  enrollmentInfo: {
+    description:
+      'This program ran from 2017 to 2024 and is not currently open for enrollment.',
+    availablePeriod: 'Program completed'
+  },
+  stages: [
+    {
+      title: 'Individual mentoring',
+      description:
+        'Personalized support in mentor-learner pairs for leadership skill development.',
+      icon: 'Users'
+    },
+    {
+      title: 'Specialized workshops',
+      description: 'Training in project management, leadership, and networking.',
+      icon: 'BookOpen'
+    },
+    {
+      title: 'In-person summit',
+      description:
+        'In-person gathering of women leaders in Miramar de Ansenuza, Cordoba.',
+      icon: 'MapPin'
+    }
+  ],
+  stats: [
+    {
+      label: 'Editions held',
+      value: '7'
+    },
+    {
+      label: 'Graduates',
+      value: '248'
+    },
+    {
+      label: 'Participating provinces',
+      value: '18'
+    },
+    {
+      label: 'Speakers',
+      value: '112'
+    }
+  ],
+  successStories: [
+    {
+      title: 'Broad national representation',
+      description:
+        'Young women from 18 provinces across Argentina took part, achieving broad national representation and forming a network of women leaders committed to their communities.'
+    }
+  ],
+  blogPosts: [],
+  faqs: [],
+  sponsors: [],
+  gallery: {
+    type: 'images',
+    images: []
+  },
+  colors: {
+    primary: '#ec4899',
+    secondary: '#db2777',
+    accent: '#f472b6'
+  }
+};
+
+export const IMPULSATEC_DATA_EN: ProgramData = {
+  title: 'ImpulsaTEC',
+  slug: 'impulsatec',
+  status: 'historical',
+  year: '2024',
+  shortDescription:
+    'Federal educational training and mentoring program designed to empower young people from inland Argentina with technology tools and soft skills to strengthen their social impact projects.',
+  fullDescription:
+    'ImpulsaTEC was a federal educational training and mentoring program designed to empower young people ages 15 to 24 from inland Argentina. Its central goal was to provide technological tools and soft skills to strengthen their social impact projects. The program aimed to build a network of committed young people who use new technologies as a driver of positive change in their communities.',
+  location: 'Federal, aimed at young people from inland Argentina.',
+  duration: 'Variable',
+  modality:
+    'Virtual program with open training sessions and biweekly mentoring, ending with an in-person experience in Buenos Aires.',
+  requirements: [
+    'Be between 15 and 24 years old.',
+    'Be from inland Argentina.',
+    'Have a social impact project or an interest in developing one.'
+  ],
+  enrollmentInfo: {
+    description:
+      'This program took place in 2024 and is not currently open for enrollment.',
+    availablePeriod: 'Program completed'
+  },
+  stages: [
+    {
+      title: 'Virtual training sessions',
+      description:
+        'Seven specialized workshops on Artificial Intelligence, Agile Methodologies, UX, Leadership, and Networking.',
+      icon: 'Monitor'
+    },
+    {
+      title: 'Mentoring with EY GDS',
+      description:
+        'Biweekly support from professional mentors at EY GDS Argentina.',
+      icon: 'Users'
+    },
+    {
+      title: 'In-person experience',
+      description:
+        'The 15 selected participants visited EY GDS offices in Buenos Aires and joined cultural and networking activities.',
+      icon: 'Building'
+    }
+  ],
+  stats: [
+    {
+      label: 'Young participants',
+      value: '500+'
+    },
+    {
+      label: 'Awardees',
+      value: '15'
+    },
+    {
+      label: 'Editions held',
+      value: '1'
+    }
+  ],
+  successStories: [
+    {
+      title: 'Strategic partnership with EY GDS Argentina',
+      description:
+        'The program was developed in partnership with EY GDS, whose specialized professionals served as mentors and strengthened the connection between the private sector and youth social commitment.'
+    },
+    {
+      title: 'Recognition for innovation',
+      description:
+        'Fifteen young people were recognized for the innovation and commitment behind their projects, receiving technology kits and funding opportunities.'
+    }
+  ],
+  blogPosts: [],
+  faqs: [],
+  sponsors: [
+    {
+      name: 'EY GDS Argentina'
+    }
+  ],
+  gallery: {
+    type: 'images',
+    images: []
+  },
+  colors: {
+    primary: '#3b82f6',
+    secondary: '#2563eb',
+    accent: '#60a5fa'
+  }
+};
+
+export const CIENCIA_FUERA_DE_LA_CAJA_DATA_EN: ProgramData = {
+  title: 'Science Outside the Box',
+  slug: 'ciencia-fuera-de-la-caja',
+  status: 'historical',
+  year: '2020',
+  shortDescription:
+    'High-impact virtual educational program and science competition designed to develop scientific thinking, creativity, and lateral thinking in young people across Argentina.',
+  fullDescription:
+    'Science Outside the Box was a high-impact virtual educational program and science competition supported by the Embassy of the United States in Argentina. Its goal was to develop scientific thinking, creativity, and lateral thinking in young people across Argentina through challenges from different branches of science.',
+  location:
+    'Nationwide, with participants from across the country divided into regions.',
+  duration: 'Variable',
+  modality:
+    'Virtual competition with practical challenges and a final in-person experience for the winners.',
+  requirements: [
+    'Be a high school student.',
+    'Be interested in science.',
+    'Complete weekly virtual challenges.'
+  ],
+  enrollmentInfo: {
+    description:
+      'This program took place in 2020 and is not currently open for enrollment.',
+    availablePeriod: 'Program completed'
+  },
+  stages: [
+    {
+      title: 'Virtual challenges',
+      description:
+        'Hands-on virtual challenges with an average 90% effectiveness in teaching key knowledge.',
+      icon: 'Lightbulb'
+    },
+    {
+      title: 'Video calls with scientists',
+      description:
+        'Sessions with leading scientists from Argentina such as Laura Frulla, Carlos Sosa, and Jeronimo Batista.',
+      icon: 'Video'
+    },
+    {
+      title: 'Creative forums',
+      description:
+        'Development of lateral thinking through creative forums averaging 73.4 posts per week.',
+      icon: 'MessageSquare'
+    },
+    {
+      title: 'Immersive prize',
+      description:
+        'The 5 winners traveled to La Cumbrecita, Cordoba, for an in-person closing experience.',
+      icon: 'Award'
+    }
+  ],
+  stats: [
+    {
+      label: 'Registered participants',
+      value: '234'
+    },
+    {
+      label: 'Female participation',
+      value: '65%'
+    },
+    {
+      label: 'New to science activities',
+      value: '44%'
+    },
+    {
+      label: 'Would recommend the program',
+      value: '83%'
+    }
+  ],
+  successStories: [
+    {
+      title: 'Proven methodology',
+      description:
+        'The program achieved an average of 90% of participants acquiring the core knowledge from each challenge.'
+    },
+    {
+      title: 'Community and networking',
+      description:
+        'Sixty-nine percent of participants built a connection or friendship with another participant, creating a youth science community.'
+    },
+    {
+      title: 'High educational impact',
+      description:
+        'The conference series with scientists generated more than 139 hours of viewing time.'
+    }
+  ],
+  blogPosts: [],
+  faqs: [],
+  sponsors: [
+    {
+      name: 'Embassy of the United States in Argentina'
+    }
+  ],
+  gallery: {
+    type: 'images',
+    images: []
+  },
+  colors: {
+    primary: '#06b6d4',
+    secondary: '#0891b2',
+    accent: '#22d3ee'
+  }
+};
+
+export const AVENTURA_MATEMATICA_DATA_EN: ProgramData = {
+  title: 'Math Adventure',
+  slug: 'aventura-matematica',
+  status: 'historical',
+  year: '2021',
+  shortDescription:
+    'Fully online initiative for young people across the country that transformed traditional science education into an immersive virtual competition combining mathematics and creativity.',
+  fullDescription:
+    'Math Adventure was a fully online, open-enrollment initiative aimed at young people across the country. The program consisted of weekly challenges that combined mathematics and creativity, complemented by occasional sessions, or symposiums, with invited scientists and mathematicians.',
+  location:
+    'Nationwide, with participants divided into five geographic regions.',
+  duration: 'Variable (8 challenges + final)',
+  modality:
+    'Immersive virtual competition with playful learning. Mathematics concepts were presented in fictional worlds such as Harry Potter and Alice in Wonderland.',
+  requirements: [
+    'Be a high school student.',
+    'Be interested in mathematics and creativity.',
+    'Complete weekly challenges in different formats such as videos, comics, and written submissions.'
+  ],
+  enrollmentInfo: {
+    description:
+      'This program took place in 2021 and is not currently open for enrollment.',
+    availablePeriod: 'Program completed'
+  },
+  stages: [
+    {
+      title: 'Stage 1: Creative challenges',
+      description:
+        'Weekly challenges set in fictional worlds, with creativity evaluated in the responses.',
+      icon: 'Wand2'
+    },
+    {
+      title: 'Stage 2: Math Wizards',
+      description:
+        'Twenty-five semifinalists received a surprise box with materials and merchandise for special challenges.',
+      icon: 'Gift'
+    },
+    {
+      title: 'Grand final',
+      description:
+        'Five finalists, one per region, competed for prizes including a computer, technology kits, and board games.',
+      icon: 'Trophy'
+    }
+  ],
+  stats: [
+    {
+      label: 'Registered participants',
+      value: '300'
+    },
+    {
+      label: 'Semifinalists',
+      value: '25'
+    },
+    {
+      label: 'Finalists',
+      value: '5'
+    },
+    {
+      label: 'Challenges completed',
+      value: '8'
+    }
+  ],
+  successStories: [
+    {
+      title: 'Innovative playful learning',
+      description:
+        'The program stood out for transforming traditional science education into an immersive and highly creative experience, making mathematical content interactive and accessible.'
+    },
+    {
+      title: 'Surprise element',
+      description:
+        'The surprise box sent to semifinalists ensured continued excitement and engagement, promoting both individual and collaborative scientific work.'
+    }
+  ],
+  blogPosts: [],
+  faqs: [],
+  sponsors: [],
+  gallery: {
+    type: 'images',
+    images: []
+  },
+  colors: {
+    primary: '#a855f7',
+    secondary: '#9333ea',
+    accent: '#c084fc'
+  }
+};
+
+export const LIDERES_DATA_EN: ProgramData = {
+  title: 'Lideres',
+  slug: 'lideres',
+  status: 'active',
+  shortDescription:
+    'Fundacion Lideres de Ansenuza program that brings together, supports, accompanies, and recognizes people who have already gone through at least one foundation program and want to keep strengthening their skills to become leaders in their communities.',
+  fullDescription:
+    'Lideres is the Fundacion Lideres de Ansenuza program responsible for bringing together, supporting, accompanying, and recognizing everyone who, after taking part in at least one foundation program, wants to continue strengthening their skills to become leaders in their communities through the implementation of new programs created exclusively for this community. Lideres focuses on support rooted in commitment, knowing that our community includes remarkable people who can achieve unimaginable things when connected with the right opportunities. We continue investing in the young people who once came through the foundation, encourage the ongoing development of their leadership, and generate post-program impact.',
+  location: 'Nationwide, aimed at former participants of FLA programs.',
+  duration: 'Ongoing',
+  modality:
+    'Active community with workshops, training, personalized support, in-person gatherings, and a biweekly mix of opportunities.',
+  requirements: [
+    'Have participated in at least one program run by Fundacion Lideres de Ansenuza.'
+  ],
+  enrollmentInfo: {
+    description:
+      'After graduating from a program, participants must complete the community entry request and, depending on the program, project registration. To do so, request it by emailing comunidad@lideresdeansenuza.org and we will contact you with the next steps.',
+    availablePeriod: 'Ongoing enrollment'
+  },
+  stages: [
+    {
+      title: 'Workshops and training',
+      description:
+        'Throughout the year, Lideres offers different initiatives such as workshops and training sessions to continue building key leadership skills.',
+      icon: 'GraduationCap'
+    },
+    {
+      title: 'Personalized support',
+      description:
+        'Personalized support for the continuity of your projects to drive the ongoing development of your leadership.',
+      icon: 'Users'
+    },
+    {
+      title: 'In-person gatherings',
+      description:
+        'In-person meetings are held in different provinces so former participants can meet and share experiences.',
+      icon: 'MapPin'
+    },
+    {
+      title: 'Opportunity mix',
+      description:
+        'Every 15 days, internal and external opportunities are shared through the initiative called "opportunity mix" so participants can keep growing.',
+      icon: 'Rocket'
+    }
+  ],
+  stats: [],
+  successStories: [
+    {
+      title: 'Milagros Tacacho',
+      description:
+        'Honestly, I am extremely grateful to the Lideres staff and FLA in general, because thanks to you I was able to better understand what I like and the initiatives I can take or create. It makes me very happy to stay connected with myself and improve every day with new tools. Please keep sharing opportunities and smiles.',
+      link: 'https://www.linkedin.com/posts/fundaci%C3%B3n-l%C3%ADderes-de-ansenuza_l%C3%ADderes-activity-7330652674113060865-Cj5Y?utm_source=share&utm_medium=member_desktop&rcm=ACoAADca_hwBU7Nri-goKb9Z9UJBItH8_u7ihkc'
+    },
+    {
+      title: 'Guillermina Rieznik',
+      description:
+        'I want to use this space to say that I love all the magic you share through the passion you put into everything. You are a wonderful staff.',
+      link: 'https://www.linkedin.com/posts/fundaci%C3%B3n-l%C3%ADderes-de-ansenuza_l%C3%ADderes-activity-7330652674113060865-Cj5Y?utm_source=share&utm_medium=member_desktop&rcm=ACoAADca_hwBU7Nri-goKb9Z9UJBItH8_u7ihkc'
+    },
+    {
+      title: 'Marilyn Mercado',
+      description:
+        'I congratulate the staff for everything they do. I have taken advantage of many opportunities.',
+      link: 'https://www.linkedin.com/posts/fundaci%C3%B3n-l%C3%ADderes-de-ansenuza_l%C3%ADderes-activity-7330652674113060865-Cj5Y?utm_source=share&utm_medium=member_desktop&rcm=ACoAADca_hwBU7Nri-goKb9Z9UJBItH8_u7ihkc'
+    }
+  ],
+  blogPosts: [
+    {
+      title: 'Mateadas and Lideres: a meeting of inspiration and connection',
+      url: 'https://www.lideresdeansenuza.org/2024/10/23/mateadas-y-lideres-un-encuentro-de-inspiracion-y-conexiones/'
+    },
+    {
+      title: 'Reliving unforgettable moments: the best of the Lideres in-person summit reunion',
+      url: 'https://www.lideresdeansenuza.org/2023/03/24/reviviendo-momentos-inolvidables-lo-mejor-de-la-cumbre-presencial-de-lideres-el-reencuentro/'
+    },
+    {
+      title: 'A diplomatic journey',
+      url: 'https://www.lideresdeansenuza.org/2023/03/22/un-viaje-diplomatico/'
+    }
+  ],
+  faqs: [
+    {
+      question: 'What is each community WhatsApp group for?',
+      answer:
+        'FLA Lideres Community: open interaction group. Info FLA: closed group where institutional information is shared. Opportunity Mix: closed group where internal and external calls are shared.'
+    },
+    {
+      question: 'Up to what age can I be part of the community?',
+      answer: 'There is no age limit to be part of the Lideres community.'
+    },
+    {
+      question: 'I took part in FLA many years ago. Can I join the community now?',
+      answer:
+        'Yes, you can be part of Lideres. Send us an email with your name and the program you were part of at comunidad@lideresdeansenuza.org and we will tell you the next steps.'
+    },
+    {
+      question: 'If I was a mentor, speaker, or teacher in an FLA program, can I be part of the community?',
+      answer:
+        'Yes, you can be part of Lideres. Send us an email with your name and the program you were part of at comunidad@lideresdeansenuza.org and we will tell you the next steps.'
+    }
+  ],
+  sponsors: [
+    {
+      name: 'EY GDS Argentina'
+    }
+  ],
+  gallery: {
+    type: 'images',
+    images: []
+  },
+  colors: {
+    primary: '#dc2626',
+    secondary: '#991b1b',
+    accent: '#f87171'
+  }
+};
+
+export const ALL_PROGRAMS_EN: ProgramData[] = [
+  AMBIENTALIA_DATA_EN,
+  SOMOS_DATA_EN,
+  POTENCIATE_DATA_EN,
+  FUTURAS_DATA_EN,
+  IMPULSATEC_DATA_EN,
+  CIENCIA_FUERA_DE_LA_CAJA_DATA_EN,
+  AVENTURA_MATEMATICA_DATA_EN,
+  LIDERES_DATA_EN
+];
+
+export const ACTIVE_PROGRAMS_EN: ProgramData[] = ALL_PROGRAMS_EN.filter(
+  (program) => program.status === 'active'
+);
+export const HISTORICAL_PROGRAMS_EN: ProgramData[] = ALL_PROGRAMS_EN.filter(
+  (program) => program.status === 'historical'
+);

--- a/lib/data/programs-i18n.ts
+++ b/lib/data/programs-i18n.ts
@@ -1,0 +1,90 @@
+import {
+  ACTIVE_PROGRAMS,
+  ALL_PROGRAMS,
+  AMBIENTALIA_DATA,
+  AVENTURA_MATEMATICA_DATA,
+  CIENCIA_FUERA_DE_LA_CAJA_DATA,
+  FUTURAS_DATA,
+  HISTORICAL_PROGRAMS,
+  IMPULSATEC_DATA,
+  LIDERES_DATA,
+  POTENCIATE_DATA,
+  SOMOS_DATA,
+  type ProgramData
+} from './programs';
+import {
+  ACTIVE_PROGRAMS_EN,
+  ALL_PROGRAMS_EN,
+  AMBIENTALIA_DATA_EN,
+  AVENTURA_MATEMATICA_DATA_EN,
+  CIENCIA_FUERA_DE_LA_CAJA_DATA_EN,
+  FUTURAS_DATA_EN,
+  HISTORICAL_PROGRAMS_EN,
+  IMPULSATEC_DATA_EN,
+  LIDERES_DATA_EN,
+  POTENCIATE_DATA_EN,
+  SOMOS_DATA_EN
+} from './programs-en';
+
+export type ProgramLocale = 'es' | 'en';
+
+export const PROGRAMS_BY_LOCALE: Record<ProgramLocale, ProgramData[]> = {
+  es: ALL_PROGRAMS,
+  en: ALL_PROGRAMS_EN
+};
+
+export const ACTIVE_PROGRAMS_BY_LOCALE: Record<ProgramLocale, ProgramData[]> = {
+  es: ACTIVE_PROGRAMS,
+  en: ACTIVE_PROGRAMS_EN
+};
+
+export const HISTORICAL_PROGRAMS_BY_LOCALE: Record<ProgramLocale, ProgramData[]> =
+  {
+    es: HISTORICAL_PROGRAMS,
+    en: HISTORICAL_PROGRAMS_EN
+  };
+
+export const PROGRAM_BY_SLUG_AND_LOCALE: Record<
+  ProgramLocale,
+  Record<string, ProgramData>
+> = {
+  es: {
+    [AMBIENTALIA_DATA.slug]: AMBIENTALIA_DATA,
+    [SOMOS_DATA.slug]: SOMOS_DATA,
+    [POTENCIATE_DATA.slug]: POTENCIATE_DATA,
+    [FUTURAS_DATA.slug]: FUTURAS_DATA,
+    [IMPULSATEC_DATA.slug]: IMPULSATEC_DATA,
+    [CIENCIA_FUERA_DE_LA_CAJA_DATA.slug]: CIENCIA_FUERA_DE_LA_CAJA_DATA,
+    [AVENTURA_MATEMATICA_DATA.slug]: AVENTURA_MATEMATICA_DATA,
+    [LIDERES_DATA.slug]: LIDERES_DATA
+  },
+  en: {
+    [AMBIENTALIA_DATA_EN.slug]: AMBIENTALIA_DATA_EN,
+    [SOMOS_DATA_EN.slug]: SOMOS_DATA_EN,
+    [POTENCIATE_DATA_EN.slug]: POTENCIATE_DATA_EN,
+    [FUTURAS_DATA_EN.slug]: FUTURAS_DATA_EN,
+    [IMPULSATEC_DATA_EN.slug]: IMPULSATEC_DATA_EN,
+    [CIENCIA_FUERA_DE_LA_CAJA_DATA_EN.slug]: CIENCIA_FUERA_DE_LA_CAJA_DATA_EN,
+    [AVENTURA_MATEMATICA_DATA_EN.slug]: AVENTURA_MATEMATICA_DATA_EN,
+    [LIDERES_DATA_EN.slug]: LIDERES_DATA_EN
+  }
+};
+
+export function getPrograms(locale: ProgramLocale): ProgramData[] {
+  return PROGRAMS_BY_LOCALE[locale];
+}
+
+export function getActivePrograms(locale: ProgramLocale): ProgramData[] {
+  return ACTIVE_PROGRAMS_BY_LOCALE[locale];
+}
+
+export function getHistoricalPrograms(locale: ProgramLocale): ProgramData[] {
+  return HISTORICAL_PROGRAMS_BY_LOCALE[locale];
+}
+
+export function getProgramBySlug(
+  locale: ProgramLocale,
+  slug: string
+): ProgramData | undefined {
+  return PROGRAM_BY_SLUG_AND_LOCALE[locale][slug];
+}

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -235,5 +235,150 @@
       "subtitle": "If you have any questions or want more information on how to participate, don't hesitate to contact us",
       "button": "Contact Us"
     }
+  },
+  "privacyPolicy": {
+    "hero": {
+      "title": "Privacy Policies",
+      "description": "On this page you will find information about how Fundacion Lideres de Ansenuza collects, uses, and protects personal data related to its programs, activities, and newsletter.",
+      "legalBaseTitle": "Legal basis",
+      "legalBaseDescription": "Law No. 25,326, Regulatory Decree No. 1558/2001, and complementary regulations.",
+      "contactChannelTitle": "Contact channel"
+    },
+    "actionCards": [
+      {
+        "title": "Form F-DP01",
+        "description": "For minors, with the signature of a parent or guardian.",
+        "label": "Open minor form"
+      },
+      {
+        "title": "Form F-DP02",
+        "description": "For adults who want to access, correct, or delete data.",
+        "label": "Open adult form"
+      },
+      {
+        "title": "AAIP complaint",
+        "description": "Official link for complaints related to personal data protection.",
+        "label": "Go to the official AAIP portal"
+      }
+    ],
+    "intro": {
+      "eyebrow": "Introduction",
+      "body": "Welcome to our privacy policy page. At Fundacion Lideres de Ansenuza, we value and respect your privacy. These policies describe how we collect, use, and protect the information you provide to us. We invite you to read them carefully so you can understand how we handle your personal data and how you can exercise your rights. If you have any questions, do not hesitate to contact us."
+    },
+    "program": {
+      "eyebrow": "Section 1",
+      "title": "Enrollment, participation in programs, and activities",
+      "sections": [
+        {
+          "title": "What does this privacy policy describe? What legislation is it based on?",
+          "body": [
+            "This Personal Data Privacy Policy describes how Fundacion Lideres de Ansenuza, with legal address at Independencia 350, Miramar de Ansenuza, Cordoba, Argentina (hereinafter, \"the foundation\"), collects, uses, and protects the personal information of people who enroll and participate in its educational programs or in activities directly organized by the foundation.",
+            "This Privacy Policy is governed by Personal Data Protection Law No. 25,326, Regulatory Decree No. 1558/2001, and other complementary regulations."
+          ]
+        },
+        {
+          "title": "What information does the foundation collect and for what purposes?",
+          "body": [
+            "The foundation collects the following information: I) Identifying data: first and last name, national ID number, date of birth, gender; II) Contact data: address, postal code, mobile phone, email address; III) Academic information: school attended and grade level; IV) Parent or guardian data (if the participant is a minor): first and last name, mobile phone, and email address.",
+            "These data are collected and stored for the purpose of efficiently managing participation in the programs, improving the quality of the services offered, ensuring effective communication, and facilitating the evaluation of the long-term impact of the programs on participants' lives."
+          ]
+        },
+        {
+          "title": "How does the foundation protect the information collected?",
+          "body": [
+            "To guarantee the privacy and security of the information collected, the foundation has several measures in place: it limits access to authorized personnel, implements technological security protocols, and does not share information with third parties without the participant's express consent, except when required by law."
+          ]
+        },
+        {
+          "title": "What are my rights and how do I exercise them?",
+          "body": [
+            "Data subjects have the right to access, correct, and delete their personal information. To do so, they must send an email to contacto@lideresdeansenuza.org, attaching a copy of the front and back of their national ID and the completed and signed form (F-DP02).",
+            "If the data subject is a minor, a copy of the front and back of the minor's national ID, a copy of the front and back of the parent's or guardian's national ID, and the completed and signed form (F-DP01) must be attached. Both forms can be found at the end of the policy."
+          ]
+        },
+        {
+          "title": "How long will the foundation keep the information?",
+          "body": [
+            "The foundation will retain your Personal Data for the time necessary to fulfill the purposes described in this Privacy Policy. Your information will be destroyed when it is no longer necessary or relevant for the purposes for which it was collected, unless there is a legal obligation to retain it for a longer period."
+          ]
+        },
+        {
+          "title": "Is it necessary to accept this privacy policy to enroll in one of the programs?",
+          "body": [
+            "By enrolling in one of our programs, you acknowledge that you have read and understood this Privacy Policy. If you are a minor, your parent or guardian must read and accept this document."
+          ]
+        },
+        {
+          "title": "Final notes",
+          "body": [
+            "The foundation reserves the right to modify this policy at any time, within the limits of applicable law. The changes will take effect after publication.",
+            "If you have any questions or concerns, contact contacto@lideresdeansenuza.org."
+          ]
+        }
+      ]
+    },
+    "newsletter": {
+      "eyebrow": "Section 2",
+      "title": "Newsletter subscription",
+      "sections": [
+        {
+          "title": "What does this privacy policy describe? What legislation is it based on?",
+          "body": [
+            "This Personal Data Privacy Policy describes how Fundacion Lideres de Ansenuza, with legal address at Independencia 350, Miramar de Ansenuza, Cordoba, Argentina (hereinafter, \"the foundation\"), collects, uses, and protects the personal information of people who subscribe to its newsletter.",
+            "This Privacy Policy is governed by Personal Data Protection Law No. 25,326, Regulatory Decree No. 1558/2001, and other complementary regulations."
+          ]
+        },
+        {
+          "title": "What information does the foundation collect and for what purposes?",
+          "body": [
+            "The foundation collects the following information: I) Identifying data: first and last name; II) Contact data: email address. These data are collected and stored for the purpose of sending relevant and up-to-date information about the foundation, including news, events, publications, and related activities. They will also be used to manage newsletter delivery and perform statistical analysis to improve its content and operation."
+          ]
+        },
+        {
+          "title": "How does the foundation protect the information collected?",
+          "body": [
+            "To guarantee the privacy and security of the information collected, the foundation has several measures in place: it limits access to authorized personnel, implements technological security protocols, and does not share information with third parties without the participant's express consent, except when required by law."
+          ]
+        },
+        {
+          "title": "What are my rights and how do I exercise them?",
+          "body": [
+            "Data subjects have the right to access, correct, and delete their personal information. To do so, they may use the links provided in each newsletter email or contact contacto@lideresdeansenuza.org by email."
+          ]
+        },
+        {
+          "title": "How long will the foundation keep the information?",
+          "body": [
+            "The foundation will retain your Personal Data for the time necessary to fulfill the purposes described in this Privacy Policy. Your information will be destroyed when it is no longer necessary or when the data subject unsubscribes from the newsletter."
+          ]
+        },
+        {
+          "title": "Is it necessary to accept this privacy policy to subscribe to the newsletter?",
+          "body": [
+            "By submitting the newsletter subscription form, the user gives express consent to the processing of personal data in accordance with the purposes established in the Privacy Policy. If you are a minor, your parent or guardian must read and accept this document."
+          ]
+        },
+        {
+          "title": "Final notes",
+          "body": [
+            "The foundation reserves the right to modify this policy at any time, within the limits of applicable law. The changes will take effect after publication.",
+            "If you have any questions or concerns, contact contacto@lideresdeansenuza.org."
+          ]
+        }
+      ]
+    },
+    "officialLink": {
+      "eyebrow": "Required official link",
+      "title": "Authority and complaint channel",
+      "description": "If you need to file a complaint related to the protection of personal data, you can do so through the official portal of the Agency for Access to Public Information.",
+      "button": "Go to the official AAIP link"
+    },
+    "help": {
+      "eyebrow": "Need help?",
+      "title": "You can write to us directly",
+      "description": "If you want to make an inquiry about your personal data or about these policies, we are available to support you.",
+      "emailButton": "Email contact",
+      "contactButton": "Go to contact"
+    }
   }
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -235,5 +235,150 @@
       "subtitle": "Si tenés alguna consulta o querés más información sobre cómo participar, no dudes en contactarnos",
       "button": "Contáctanos"
     }
+  },
+  "privacyPolicy": {
+    "hero": {
+      "title": "Politicas de privacidad",
+      "description": "En esta pagina vas a encontrar la informacion sobre como Fundacion Lideres de Ansenuza recopila, utiliza y protege los datos personales vinculados a sus programas, actividades y newsletter.",
+      "legalBaseTitle": "Base legal",
+      "legalBaseDescription": "Ley N 25.326, Decreto Reglamentario N 1558/2001 y normas complementarias.",
+      "contactChannelTitle": "Canal de contacto"
+    },
+    "actionCards": [
+      {
+        "title": "Formulario F-DP01",
+        "description": "Para titulares menores de edad, con firma de padre, madre o tutor.",
+        "label": "Abrir formulario menor de edad"
+      },
+      {
+        "title": "Formulario F-DP02",
+        "description": "Para titulares mayores de edad que quieran acceder, corregir o suprimir datos.",
+        "label": "Abrir formulario mayor de edad"
+      },
+      {
+        "title": "Reclamo ante la AAIP",
+        "description": "Enlace oficial para reclamos vinculados a proteccion de datos personales.",
+        "label": "Ir al portal oficial de la AAIP"
+      }
+    ],
+    "intro": {
+      "eyebrow": "Introduccion",
+      "body": "Te damos la bienvenida a nuestra pagina de politicas de privacidad. En Fundacion Lideres de Ansenuza valoramos y respetamos tu privacidad. Estas politicas describen como recopilamos, usamos y protegemos la informacion que nos proporcionas. Te invitamos a leer detenidamente para comprender como tratamos tus datos personales y como podes ejercer tus derechos. Si tenes alguna pregunta, no dudes en ponerte en contacto con nosotros."
+    },
+    "program": {
+      "eyebrow": "Seccion 1",
+      "title": "Inscripcion, participacion en programas y actividades",
+      "sections": [
+        {
+          "title": "Que describe esta politica de privacidad? En que legislacion se basa?",
+          "body": [
+            "La presente Politica de Privacidad de Datos Personales describe como la Fundacion Lideres de Ansenuza, con domicilio legal en Independencia 350, Miramar de Ansenuza, Cordoba, Argentina (en adelante, \"la fundacion\") recopila, utiliza y protege la informacion personal de aquellas personas que se inscriben y participan en sus programas educativos o en actividades directamente organizadas por la fundacion.",
+            "Esta Politica de Privacidad se rige por la Ley N 25.326 de Proteccion de Datos Personales, su Decreto Reglamentario N 1558/2001 y demas normas complementarias."
+          ]
+        },
+        {
+          "title": "Que informacion recopila la fundacion y con que fines?",
+          "body": [
+            "La fundacion recopila la siguiente informacion: I) Datos identificativos: nombre y apellido, DNI, fecha de nacimiento, genero; II) Datos de contacto: domicilio, codigo postal, telefono movil, correo electronico; III) Informacion academica: colegio al que asiste y curso; IV) Datos del padre, madre o tutor (en caso de ser menor de edad): nombre y apellido, telefono movil y correo electronico.",
+            "Estos datos se recopilan y almacenan con el proposito de gestionar eficientemente la participacion en los programas, mejorar la calidad de los servicios ofrecidos, asegurar una comunicacion efectiva y facilitar la evaluacion del impacto a largo plazo de los programas en la vida de los participantes."
+          ]
+        },
+        {
+          "title": "Como protege la fundacion la informacion recopilada?",
+          "body": [
+            "Con el fin de garantizar la privacidad y seguridad de la informacion recopilada la fundacion tiene varias medidas en funcionamiento: limita el acceso a personal autorizado, implementa protocolos de seguridad tecnologica y no comparte la informacion con terceros sin el consentimiento expreso del participante, excepto cuando sea requerido por ley."
+          ]
+        },
+        {
+          "title": "Cuales son mis derechos y como los ejerzo?",
+          "body": [
+            "Los titulares de los datos personales tienen el derecho de acceder, corregir y suprimir su informacion personal. Para hacerlo deben enviar un correo electronico a contacto@lideresdeansenuza.org, adjuntando una copia del frente y dorso de su DNI y el formulario (F-DP02) completo y firmado.",
+            "En caso de que el titular de la informacion sea menor de edad, se debera adjuntar una copia del frente y dorso del DNI del titular, una copia del frente y dorso del DNI del padre, madre o tutor y el formulario (F-DP01) completo y firmado. Ambos formularios se pueden encontrar al final de la politica."
+          ]
+        },
+        {
+          "title": "Cuanto tiempo conservara la fundacion la informacion?",
+          "body": [
+            "La fundacion conservara sus Datos Personales por el tiempo necesario para el cumplimiento de las finalidades descritas en la presente Politica de Privacidad. Su informacion sera destruida cuando haya dejado de ser necesaria o pertinente a los fines para los cuales hubiese sido recolectada, salvo que exista una obligacion legal de conservarla por un termino mayor."
+          ]
+        },
+        {
+          "title": "Es necesario aceptar esta politica de privacidad para inscribirse a uno de sus programas?",
+          "body": [
+            "Al inscribirse en alguno de nuestros programas, usted reconoce haber leido y comprendido esta Politica de Privacidad. Si usted es menor de edad, su padre, madre o tutor debera leer y aceptar el presente documento."
+          ]
+        },
+        {
+          "title": "Aclaraciones finales",
+          "body": [
+            "La fundacion se reserva el derecho de modificar esta politica en cualquier momento, dentro de la ley vigente. Los cambios entraran en vigencia despues de su publicacion.",
+            "Si tiene alguna pregunta o inquietud comuniquese con contacto@lideresdeansenuza.org."
+          ]
+        }
+      ]
+    },
+    "newsletter": {
+      "eyebrow": "Seccion 2",
+      "title": "Suscripcion a newsletter",
+      "sections": [
+        {
+          "title": "Que describe esta politica de privacidad? En que legislacion se basa?",
+          "body": [
+            "La presente Politica de Privacidad de Datos Personales describe como la Fundacion Lideres de Ansenuza, con domicilio legal en Independencia 350, Miramar de Ansenuza, Cordoba, Argentina (en adelante, \"la fundacion\") recopila, utiliza y protege la informacion personal de aquellas personas que se suscriben en su Newsletter.",
+            "Esta Politica de Privacidad se rige por la Ley N 25.326 de Proteccion de Datos Personales, su Decreto Reglamentario N 1558/2001 y demas normas complementarias."
+          ]
+        },
+        {
+          "title": "Que informacion recopila la fundacion y con que fines?",
+          "body": [
+            "La fundacion recopila la siguiente informacion: I) Datos identificativos: nombre y apellido; II) Datos de contacto: correo electronico. Estos datos se recopilan y almacenan con el proposito de enviar informacion relevante y actualizada sobre la fundacion, incluyendo noticias, eventos, publicaciones y actividades relacionadas. Ademas, se utilizaran para gestionar el envio del Newsletter y realizar analisis estadisticos para mejorar su contenido y funcionamiento."
+          ]
+        },
+        {
+          "title": "Como protege la fundacion la informacion recopilada?",
+          "body": [
+            "Con el fin de garantizar la privacidad y seguridad de la informacion recopilada, la fundacion tiene varias medidas en funcionamiento: limita el acceso a personal autorizado, implementa protocolos de seguridad tecnologica y no comparte la informacion con terceros sin el consentimiento expreso del participante, excepto cuando sea requerido por ley."
+          ]
+        },
+        {
+          "title": "Cuales son mis derechos y como los ejerzo?",
+          "body": [
+            "Los titulares de los datos personales tienen el derecho de acceder, corregir y suprimir su informacion personal. Para hacerlo el titular puede utilizar los enlaces proporcionados en cada correo electronico del Newsletter o contactarse por correo electronico a contacto@lideresdeansenuza.org."
+          ]
+        },
+        {
+          "title": "Cuanto tiempo conservara la fundacion la informacion?",
+          "body": [
+            "La fundacion conservara sus Datos Personales por el tiempo necesario para el cumplimiento de las finalidades descritas en la presente Politica de Privacidad. Su informacion sera destruida cuando haya dejado de ser necesaria o cuando el titular de los datos de de baja del newsletter."
+          ]
+        },
+        {
+          "title": "Es necesario aceptar esta politica de privacidad para darse de alta en el Newsletter?",
+          "body": [
+            "Al enviar el formulario de alta en el Newsletter, el usuario otorga su consentimiento expreso para el tratamiento de sus datos personales de acuerdo con los fines establecidos en la Politica de Privacidad. Si usted es menor de edad, su padre, madre o tutor debera leer y aceptar el presente documento."
+          ]
+        },
+        {
+          "title": "Aclaraciones finales",
+          "body": [
+            "La fundacion se reserva el derecho de modificar esta politica en cualquier momento, dentro de la ley vigente. Los cambios entraran en vigencia despues de su publicacion.",
+            "Si tiene alguna pregunta o inquietud comuniquese con contacto@lideresdeansenuza.org."
+          ]
+        }
+      ]
+    },
+    "officialLink": {
+      "eyebrow": "Enlace oficial obligatorio",
+      "title": "Autoridad de aplicacion y canal de reclamo",
+      "description": "Si necesitas realizar un reclamo vinculado a la proteccion de datos personales, podes hacerlo a traves del portal oficial de la Agencia de Acceso a la Informacion Publica.",
+      "button": "Ir al enlace oficial AAIP"
+    },
+    "help": {
+      "eyebrow": "Necesitas ayuda?",
+      "title": "Podes escribirnos directo",
+      "description": "Si queres hacer una consulta sobre tus datos personales o sobre estas politicas, estamos disponibles para acompanarte.",
+      "emailButton": "Escribir a contacto",
+      "contactButton": "Ir a contacto"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Restore and keep the donation/contact i18n changes from the stash.
- Add localized program datasets and locale helpers under `lib/data`.
- Keep the donation page on the new PayPal widget flow.

## Validation
- `pnpm lint` could not run in this environment because `next` is not available on PATH (`next` missing from local installation).
