### PR TITLE
Consolidate about us organigram and programs layout

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -65,10 +65,10 @@
       "title": "THE FOUNDATION",
       "imageAlt": "Fundación Líderes de Ansenuza team",
       "intro": "Fundación Líderes de Ansenuza is a non-governmental organization based in Miramar de Ansenuza, Córdoba, whose work revolves around the design and execution of educational programs in Argentina.",
-      "paragraph1": "At Fundación Líderes de Ansenuza (FLA), we believe in the potential of every young person to transform their community and build a better future. Our mission is to train agents of change, offering opportunities, tools, and support for young people to develop leadership and generate social impact.",
-      "paragraph2": "We work throughout Argentina, with special attention to rural and semi-urban regions, as well as large cities. Our goal is to reach those who need it most, providing hands-on experiences, without economic barriers, that promote learning through action and innovation.",
-      "paragraph3": "FLA not only focuses on training leaders but also on creating an inclusive, diverse, and committed community where young people find a safe space to enhance their ideas and sustainable projects.",
-      "paragraph4": "Being part of FLA means being part of a movement that bets on equal opportunities and the power of youth to generate real and lasting impact. Together, we are building a future full of possibilities and leadership for everyone."
+      "paragraph1": "The purpose of Fundación Líderes de Ansenuza is to be a support network that helps young people grow into agents of change.",
+      "paragraph2": "To achieve that, we offer opportunities, tools, and guidance that strengthen leadership development in their communities.",
+      "paragraph3": "Unlike other spaces that focus on theory, FLA promotes learning through concrete action. Participants not only gain knowledge, they apply it in real projects. Their work goes beyond daily tasks: they impact lives and build a better future.",
+      "paragraph4": "Our Foundation is made up of volunteers and participants from more than 18 provinces across the country and even reaches people abroad. Our meetings are hybrid: virtual sessions alternate with in-person gatherings. This makes a holistic transformation possible: our young people not only gain knowledge, but also build a 'second FLAmilia' where many find a safe, motivating, and challenging space."
     },
     "authorities": {
       "title": "Authorities",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -65,10 +65,10 @@
       "title": "LA FUNDACIÓN",
       "imageAlt": "Equipo de la Fundación Líderes de Ansenuza",
       "intro": "La Fundación Líderes de Ansenuza es una organización no gubernamental con sede en Miramar de Ansenuza, Córdoba, cuyo trabajo gira en torno al diseño y ejecución de programas educativos en el territorio argentino.",
-      "paragraph1": "En la Fundación Líderes de Ansenuza (FLA), creemos en el potencial de cada joven para transformar su comunidad y construir un futuro mejor. Nuestra misión es formar agentes de cambio, ofreciendo oportunidades, herramientas y acompañamiento para que los jóvenes desarrollen liderazgo y generen impacto social.",
-      "paragraph2": "Trabajamos en todo el territorio argentino, con especial atención a las regiones rurales y semiurbanas, así como a las grandes ciudades. Nuestro objetivo es llegar a quienes más lo necesitan, brindando experiencias vivenciales, sin barreras económicas, que promueven el aprendizaje mediante la acción y la innovación.",
-      "paragraph3": "FLA no solo se centra en la formación de líderes, sino en crear una comunidad inclusiva, diversa y comprometida, donde los jóvenes encuentran un espacio seguro para potenciar sus ideas y proyectos sostenibles.",
-      "paragraph4": "Estar en FLA significa ser parte de un movimiento que apuesta a la igualdad de oportunidades y al poder de la juventud para generar un impacto real y duradero. Juntos, estamos construyendo un futuro lleno de posibilidades y liderazgo para todos."
+      "paragraph1": "El propósito en la Fundación Líderes de Ansenuza es ser una red de apoyo que impulse la formación de jóvenes como agentes de cambio.",
+      "paragraph2": "Para lograrlo, proponemos oportunidades, herramientas y acompañamiento que impulsen el desarrollo de liderazgo en sus comunidades.",
+      "paragraph3": "A diferencia de otros espacios que se enfocan en la teoría, FLA promueve el aprendizaje a través de la acción concreta. Los participantes no solo adquieren conocimientos, sino que los aplican en proyectos reales. Su trabajo trasciende las tareas diarias: impactan vidas y construyen un futuro mejor.",
+      "paragraph4": "Nuestra Fundación está conformada por personas voluntarias y participantes de más de 18 provincias del territorio nacional e incluso, con alcance a países del extranjero. La modalidad de encuentros es híbrida: se alternan reuniones virtuales y encuentros presenciales. Esto permite una transformación integral: nuestros jóvenes no solo adquieren conocimientos, sino que también se crea una “segunda FLAmilia” en donde muchos encuentran un espacio seguro, motivador y desafiante."
     },
     "authorities": {
       "title": "Autoridades",


### PR DESCRIPTION
## Summary
- Update the "Qui?nes somos" authorities section with a visual organigram.
- Add LinkedIn-linked profile cards for the board and leadership team.
- Include optimized WebP staff photos and remove the extra LinkedIn button text.
- Keep the earlier copy updates for the About Us section.
- Preserve the three-column desktop layout for active programs.

## Validation
- `git diff --check`
- Converted staff images to WebP and removed the original JPEG/PNG files.
